### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,3 +233,8 @@ MIT License — Free and open source
 **Zero drift. Eternal sync. AI optimized.** 🏆
 
 *"It's so logical if it didn't exist, AI would have built it itself" — Claude*
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/wolfe-jam-faf-mcp).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/wolfe-jam-faf-mcp)