### PR TITLE
ci: remove npm publish step — preempt the red-badge race with /pubpro

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,49 +167,6 @@ jobs:
           echo "Directory operations: <30ms ✅"
           echo "Format operations: <1ms ✅"
 
-  # 📦 Publish (only on release)
-  publish:
-    name: 📦 Publish to NPM
-    runs-on: ubuntu-latest
-    needs: [build, performance]
-    if: github.event_name == 'release'
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
-
-      - name: Publish to NPM
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Create GitHub Release Assets
-        run: |
-          npm pack
-          mv *.tgz faf-mcp-${{ github.event.release.tag_name }}.tgz
-
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./faf-mcp-${{ github.event.release.tag_name }}.tgz
-          asset_name: faf-mcp-${{ github.event.release.tag_name }}.tgz
-          asset_content_type: application/gzip
-
   # 🏆 Championship Status
   status:
     name: 🏆 Championship Status


### PR DESCRIPTION
## Summary
- Deletes the `📦 Publish to NPM` job from `.github/workflows/ci.yml`
- `/pubpro` is the single source of truth for publishing; CI should only validate
- Preemptive — same pattern is actively red on [claude-faf-mcp](https://www.npmjs.com/package/claude-faf-mcp) (see Wolfe-Jam/claude-faf-mcp#50). Fixing here before the next release trips it.

## Root cause
CI's publish step fires on `release` events and races `/pubpro`'s manual `npm publish`. Pubpro ships first, CI then hits:

```
npm error 404 '<pkg>@<ver>' is not in this registry.
```

…and the badge flips red even though the package published fine.

## Test plan
- [ ] Merge → next push runs CI without the publish job
- [ ] Confirm `/pubpro` publish flow still works end-to-end on the next release
- [ ] Badge stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)