### PR TITLE
fix(ci): run tests in-band — kill the worker-exit flake at the source

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,9 +18,11 @@ module.exports = {
   ],
   coverageDirectory: 'coverage',
   verbose: true,
-  // Tests pass cleanly, but benign exec/server handles can linger past the
-  // worker's exit check on CI runners (Windows/macOS), force-exiting a worker
-  // non-zero. Not a test failure — Jest's documented finish for lingering
-  // resources. Pairs with the memoized CLI detection (fewer handles).
-  forceExit: true
+  // Tests run in-band (package.json `test` → `jest --runInBand`). These MCP
+  // suites are small; serial execution removes Jest's worker pool — the source
+  // of the intermittent "worker failed to exit gracefully" red on constrained
+  // Windows/macOS CI runners (a worker missing its shutdown window, blaming
+  // whichever suite finalized last). In-band is deterministic and exits clean
+  // on its own: --detectOpenHandles reports ZERO open handles, so no forceExit
+  // is needed (and forceExit was suppressing that very diagnostic).
 };

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dev": "ts-node src/server.ts",
     "dev:stdio": "ts-node src/cli.ts --transport stdio",
     "dev:http": "ts-node src/cli.ts --transport http-sse --port 3001",
-    "test": "jest",
+    "test": "jest --runInBand",
     "test:performance": "jest tests/performance.test.ts",
     "test:mcp": "mcp-inspector stdio ts-node src/cli.ts",
     "lint": "eslint src/**/*.ts",


### PR DESCRIPTION
## Root cause (fresh investigation)

The intermittent **"worker failed to exit gracefully and has been force exited"** red was **not** an open-handle leak.

`npx jest --detectOpenHandles --no-coverage --no-forceExit` (in-band) reports **ZERO open handles** across all 8 suites, **299/299 passing** — including `desktop-native-validation` and `interop-v450`, the suites that intermittently failed on CI.

It's a **Jest worker-pool shutdown flake**: under ts-jest on constrained Windows/macOS runners a worker occasionally misses its shutdown window and is force-exited, with blame landing on whichever suite *finalized last* (explains the varying failed suite + always N−1 passing).

## Fix

- **`jest --runInBand`** — no worker pool → the worker-death class is structurally impossible. Suites are small; serial cost is seconds.
- **Removed `forceExit: true`** — it never fixed a dying worker (only force-quits the *main* process) and it **suppressed the `--detectOpenHandles` report**, blinding 3 prior diagnoses. In-band exits clean on its own.

Prior attempts (memoized `cli-detector`, `forceExit`) chased a handle that doesn't exist — `execSync` is synchronous, it cannot leave an async handle.

## Proof
- Local `npm test -- --coverage` (now in-band): exit 0, 299/299, **no worker warning, no force-exit**.
- This PR's CI run is the real proof across the Windows/macOS × Node matrix.

If green here, the same fix fans to grok-faf-mcp + claude-faf-mcp (shared `jest.config.js` + test script).