### PR TITLE
fix(test): harden desktop-native cwd isolation (latent bug)

### DIFF
--- a/tests/desktop-native-validation.test.ts
+++ b/tests/desktop-native-validation.test.ts
@@ -19,11 +19,13 @@ const getTextContent = (content: unknown[]): string =>
 
 describe('🏁 Desktop-Native MCP Championship Tests', () => {
   let testDir: string;
+  let originalCwd: string;
 
   beforeAll(async () => {
     // Create isolated test environment
     testDir = path.join('/tmp', `faf-desktop-test-${Date.now()}`);
     fs.mkdirSync(testDir, { recursive: true });
+    originalCwd = process.cwd();
     process.chdir(testDir);
 
     // Initialize server WITHOUT CLI (for validation but not used in tests)
@@ -35,8 +37,10 @@ describe('🏁 Desktop-Native MCP Championship Tests', () => {
   });
   
   afterAll(async () => {
-    // Cleanup
-    process.chdir('/');
+    // Restore the original cwd — chdir('/') here left cwd polluted for later
+    // suites in single-process runs (in-band / bun). Harmless today by suite
+    // order, but a latent isolation bug; restore makes it robust + bun-ready.
+    process.chdir(originalCwd);
     fs.rmSync(testDir, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
Defensive follow-up to #43. `desktop-native`'s `afterAll` did `chdir('/')` without restoring cwd — harmless today (faf-mcp passes by suite order) but the **same latent isolation bug** that broke grok's Windows security test and claude's cwd-relative suites once the worker pool was removed. Restoring `originalCwd` makes faf-mcp robust to suite-order changes and ready for the bun migration (single-process). 299/299 local.