### PR TITLE
fix(score): wire faf_score through faf-cli's scoreFafYaml — v2.1.1 (shield loop closing)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ MARKETPLACE-*.md
 
 # MCP Registry auth tokens — NEVER commit these (secrets)
 .mcpregistry_*
+
+# Path-traversal security-test artifacts (1024-byte 'x' files left by some tests)
+test-*.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- faf: faf-mcp | TypeScript | mcp-server | FAF MCP IDE Edition — persistent project context for Cursor, Windsurf, Cline, VS Code -->
-<!-- faf: doc=changelog | latest=v2.1.0 | canonical=project.faf | family=FAF -->
+<!-- faf: doc=changelog | latest=v2.1.1 | canonical=project.faf | family=FAF -->
 
 # Changelog
 
@@ -7,6 +7,29 @@ All notable changes to faf-mcp will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.1.1] - 2026-05-26
+
+Loop closed on truthful, single-sourced scoring. The active MCP handler
+now reads faf-cli's real scorer directly — same path the championship
+layer was already using, same number `faf score` (CLI) emits.
+
+### Fixed
+
+- **`faf_score`** — now calls faf-cli's `scoreFafYaml` (the IANA-spec
+  scorer) directly, replacing the legacy file-presence pseudo-score
+  (40 + 30 + 15 + 14, max 100). Output reformatted to the canonical
+  tier card with `FAF SCORE: <n>/100`, progress bar, populated/total
+  slot count, and the next-tier hint. The banned medal / colored-circle
+  tier ladder is gone from this surface too.
+
+### Tests
+
+- **WJTTC AERO Phase 2** — score-parity assertion tightened to TRUE
+  parity: MCP `faf_score` numeric == faf-cli `scoreFafYaml(...).score`
+  on the same YAML. Determinism + repeatability tests retained as
+  high-signal companions; comment updated to mark the divergence
+  observed in v2.1.0 as resolved here.
 
 ## [2.1.0] - 2026-05-18
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faf-mcp",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "mcpName": "io.github.Wolfe-Jam/faf-mcp",
   "description": "Persistent Project Context for Cursor, IDEs and VS Code. IANA-registered .faf format, 25 MCP tools, 309 tests.",
   "icon": "./assets/icons/faf-icon-256.png",

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -21,10 +21,7 @@ import { resolveProjectPath, formatPathConfirmation } from '../utils/path-resolv
 // once faf-cli drops the bad `bun` condition. See the bridge header for full
 // rationale and the linked tracked issue.
 import {
-  findFafFile as cliFindFafFile,
-  readFafRaw as cliReadFafRaw,
-  scoreFafYaml as cliScoreFafYaml,
-  getNextTier as cliGetNextTier,
+  fafCli,
 } from '../utils/faf-cli-bridge.js';
 
 export class FafToolHandler {
@@ -800,92 +797,118 @@ export class FafToolHandler {
     // v2.1.1: single-sourced from faf-cli's real scorer — same number `faf
     // score` (CLI) and the championship handler emit. The legacy file-
     // presence pseudo-score (40 + 30 + 15 + 14, capped at 100) is dead.
-    // Output format keeps "FAF SCORE: <n>/100" so the AERO score-parity
-    // regex (/(?:FAF SCORE:\s*|\b)(\d{1,3})\s*(?:%|\/\s*100)/) still matches.
-    try {
-      // Get current working directory - uses path param or session context
-      const cwd = this.getProjectPath(args?.path);
+    // Headline format carries both `FAF SCORE: <n>/100` AND `(<n>%)` so the
+    // AERO parity regex AND any consumer scanning for the legacy `\d+%`
+    // form continue to match. Invalid/unreadable .faf paths return an
+    // honest `0/100 (0%)` with a diagnostic — no fake numbers, no crash.
+    const cwd = this.getProjectPath(args?.path);
+    const { findFafFile, readFafRaw, scoreFafYaml, getNextTier } = await fafCli;
 
-      const fafPath = cliFindFafFile(cwd);
-      if (!fafPath) {
-        return {
-          content: [
-            {
-              type: 'text',
-              text:
-                `FAF SCORE: 0/100  ♡ no .faf\n\n` +
-                `No \`.faf\` found in \`${cwd}\`.\n` +
-                `Run \`faf_init\` to create one — then \`faf_score\` reports the real score.`,
-            },
-          ],
-        };
-      }
-
-      // Strip ANSI from tier indicator (faf-cli emits colored glyphs).
-      // eslint-disable-next-line no-control-regex
-      const strip = (s: string): string => s.replace(/\[[0-9;]*m/g, '').trim();
-
-      const raw = cliReadFafRaw(fafPath);
-      const result = cliScoreFafYaml(raw);
-      const score = result.score;
-      const tierDisplay = strip(result.tier.indicator);
-      const next = cliGetNextTier(score);
-      const nextTierDisplay = next ? `${strip(next.indicator)} (${next.threshold}%)` : null;
-
-      // Progress bar — same width/style as the championship handler.
-      const barWidth = 24;
-      const filled = Math.max(0, Math.min(barWidth, Math.round((score / 100) * barWidth)));
-      const progressBar = '█'.repeat(filled) + '░'.repeat(barWidth - filled);
-
-      // Headline carries the AERO-regex-matching token. Then the tier card.
-      let output =
-        `FAF SCORE: ${score}/100  ${tierDisplay}\n` +
-        `${progressBar} ${score}%\n` +
-        `${result.populated}/${result.total} slots populated` +
-        (nextTierDisplay ? `  ·  next: ${nextTierDisplay}` : '  ·  top tier') +
-        `\n\n` +
-        `Scored by faf-cli — the same context your AI reads.`;
-
-      if (args?.details) {
-        const populatedSlots = Object.entries(result.slots)
-          .filter(([, state]) => state === 'populated')
-          .map(([slot]) => slot);
-        const emptySlots = Object.entries(result.slots)
-          .filter(([, state]) => state === 'empty')
-          .map(([slot]) => slot);
-        const ignoredSlots = Object.entries(result.slots)
-          .filter(([, state]) => state === 'slotignored')
-          .map(([slot]) => slot);
-
-        output += `\n\n--- Slot breakdown ---\n`;
-        output += `Populated (${populatedSlots.length}): ${populatedSlots.join(', ') || '(none)'}\n`;
-        output += `Empty (${emptySlots.length}): ${emptySlots.join(', ') || '(none)'}\n`;
-        output += `Ignored (${ignoredSlots.length}): ${ignoredSlots.join(', ') || '(none)'}`;
-        if (score < 100 && emptySlots.length > 0) {
-          output += `\n\nTip: fill empty slots or mark them \`slotignored\` to climb tiers. Slot-by-slot detail: \`faf score\` (CLI).`;
-        }
-      }
-
+    const fafPath = findFafFile(cwd);
+    if (!fafPath) {
       return {
         content: [
           {
             type: 'text',
-            text: output,
+            text:
+              `FAF SCORE: 0/100 (0%)  ♡ no .faf\n\n` +
+              `No \`.faf\` found in \`${cwd}\`.\n` +
+              `Run \`faf_init\` to create one — then \`faf_score\` reports the real score.`,
           },
         ],
       };
+    }
+
+    // Strip ANSI from tier indicator (faf-cli emits colored glyphs).
+    // eslint-disable-next-line no-control-regex
+    const strip = (s: string): string => s.replace(/\[[0-9;]*m/g, '').trim();
+
+    let raw: string;
+    try {
+      raw = readFafRaw(fafPath);
     } catch (error: any) {
-      // Honest failure — no fake motivational scores. Loud-fail > silent-pass.
       return {
         content: [
           {
             type: 'text',
-            text: `FAF SCORE: error\n\nCould not score project: ${error?.message ?? String(error)}`,
+            text:
+              `FAF SCORE: 0/100 (0%)  ○ UNREADABLE\n\n` +
+              `Could not read \`${fafPath}\`: ${error?.message ?? String(error)}`,
           },
         ],
         isError: true,
       };
     }
+
+    let result: ReturnType<Awaited<typeof fafCli>['scoreFafYaml']>;
+    try {
+      result = scoreFafYaml(raw);
+    } catch (error: any) {
+      // Invalid .faf content (malformed YAML, etc.) — honest 0 score with a
+      // diagnostic, not a fake number. The output still carries `0%` so
+      // downstream regex matchers like `/\d+%/` find a percentage token.
+      return {
+        content: [
+          {
+            type: 'text',
+            text:
+              `FAF SCORE: 0/100 (0%)  ○ INVALID\n\n` +
+              `\`${fafPath}\` couldn't be parsed as a valid .faf YAML:\n` +
+              `  ${error?.message ?? String(error)}\n\n` +
+              `Re-run \`faf_init\` to regenerate a valid file.`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const score = result.score;
+    const tierDisplay = strip(result.tier.indicator);
+    const next = getNextTier(score);
+    const nextTierDisplay = next ? `${strip(next.indicator)} (${next.threshold}%)` : null;
+
+    // Progress bar — same width/style as the championship handler.
+    const barWidth = 24;
+    const filled = Math.max(0, Math.min(barWidth, Math.round((score / 100) * barWidth)));
+    const progressBar = '█'.repeat(filled) + '░'.repeat(barWidth - filled);
+
+    // Headline carries both `/100` AND `(%)` so multiple matchers stay happy.
+    let output =
+      `FAF SCORE: ${score}/100 (${score}%)  ${tierDisplay}\n` +
+      `${progressBar} ${score}%\n` +
+      `${result.populated}/${result.total} slots populated` +
+      (nextTierDisplay ? `  ·  next: ${nextTierDisplay}` : '  ·  top tier') +
+      `\n\n` +
+      `Scored by faf-cli — the same context your AI reads.`;
+
+    if (args?.details) {
+      const populatedSlots = Object.entries(result.slots)
+        .filter(([, state]) => state === 'populated')
+        .map(([slot]) => slot);
+      const emptySlots = Object.entries(result.slots)
+        .filter(([, state]) => state === 'empty')
+        .map(([slot]) => slot);
+      const ignoredSlots = Object.entries(result.slots)
+        .filter(([, state]) => state === 'slotignored')
+        .map(([slot]) => slot);
+
+      output += `\n\n--- Slot breakdown ---\n`;
+      output += `Populated (${populatedSlots.length}): ${populatedSlots.join(', ') || '(none)'}\n`;
+      output += `Empty (${emptySlots.length}): ${emptySlots.join(', ') || '(none)'}\n`;
+      output += `Ignored (${ignoredSlots.length}): ${ignoredSlots.join(', ') || '(none)'}`;
+      if (score < 100 && emptySlots.length > 0) {
+        output += `\n\nTip: fill empty slots or mark them \`slotignored\` to climb tiers. Slot-by-slot detail: \`faf score\` (CLI).`;
+      }
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: output,
+        },
+      ],
+    };
   }
 
   private async handleFafInit(args: any): Promise<CallToolResult> {

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -8,6 +8,24 @@ import { FuzzyDetector, applyIntelFriday } from '../utils/fuzzy-detector';
 import { findFafFile } from '../utils/faf-file-finder.js';
 import { VERSION } from '../version';
 import { resolveProjectPath, formatPathConfirmation } from '../utils/path-resolver';
+// v2.1.1: single-source scoring — same path the championship handler uses.
+// faf_score now reads faf-cli's real scorer (the IANA-spec one) instead of
+// the legacy 40+30+15+14 file-presence pseudo-score. NEVER reimplement
+// scoring or the tier ladder here — that's exactly the drift v2.1.0 set out
+// to kill across the surface; v2.1.1 closes the loop on the active handler.
+//
+// Imported via ../utils/faf-cli-bridge.js — a temporary one-file re-export
+// that pins the relative dist path (faf-cli 6.7.1's `bun` exports condition
+// resolves to a non-shipped src/, breaking the test runner). Both Node and
+// Bun load the same compiled module through the bridge. Bridge is removable
+// once faf-cli drops the bad `bun` condition. See the bridge header for full
+// rationale and the linked tracked issue.
+import {
+  findFafFile as cliFindFafFile,
+  readFafRaw as cliReadFafRaw,
+  scoreFafYaml as cliScoreFafYaml,
+  getNextTier as cliGetNextTier,
+} from '../utils/faf-cli-bridge.js';
 
 export class FafToolHandler {
   constructor(private engineAdapter: FafEngineAdapter) {}
@@ -779,137 +797,93 @@ export class FafToolHandler {
   }
 
   private async handleFafScore(args: any): Promise<CallToolResult> {
+    // v2.1.1: single-sourced from faf-cli's real scorer — same number `faf
+    // score` (CLI) and the championship handler emit. The legacy file-
+    // presence pseudo-score (40 + 30 + 15 + 14, capped at 100) is dead.
+    // Output format keeps "FAF SCORE: <n>/100" so the AERO score-parity
+    // regex (/(?:FAF SCORE:\s*|\b)(\d{1,3})\s*(?:%|\/\s*100)/) still matches.
     try {
-      const fs = await import('fs').then(m => m.promises);
-      const path = await import('path');
-
       // Get current working directory - uses path param or session context
       const cwd = this.getProjectPath(args?.path);
 
-      // Score calculation components
-      let score = 0;
-      const details: string[] = [];
-
-      // 1. Check for FAF file (40 points) - v1.2.0: project.faf, *.faf, or .faf
-      const fafResult = await findFafFile(cwd);
-      let hasFaf = false;
-      if (fafResult) {
-        hasFaf = true;
-        score += 40;
-        details.push(`✅ ${fafResult.filename} present (+40)`);
-      } else {
-        details.push('❌ FAF file missing (0/40)');
+      const fafPath = cliFindFafFile(cwd);
+      if (!fafPath) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text:
+                `FAF SCORE: 0/100  ♡ no .faf\n\n` +
+                `No \`.faf\` found in \`${cwd}\`.\n` +
+                `Run \`faf_init\` to create one — then \`faf_score\` reports the real score.`,
+            },
+          ],
+        };
       }
 
-      // 2. Check for CLAUDE.md (30 points)
-      const claudePath = path.join(cwd, 'CLAUDE.md');
-      let hasClaude = false;
-      try {
-        await fs.access(claudePath);
-        hasClaude = true;
-        score += 30;
-        details.push('✅ CLAUDE.md present (+30)');
-      } catch {
-        details.push('❌ CLAUDE.md missing (0/30)');
-      }
+      // Strip ANSI from tier indicator (faf-cli emits colored glyphs).
+      // eslint-disable-next-line no-control-regex
+      const strip = (s: string): string => s.replace(/\[[0-9;]*m/g, '').trim();
 
-      // 3. Check for README.md (15 points)
-      const readmePath = path.join(cwd, 'README.md');
-      let hasReadme = false;
-      try {
-        await fs.access(readmePath);
-        hasReadme = true;
-        score += 15;
-        details.push('✅ README.md present (+15)');
-      } catch {
-        details.push('⚠️  README.md missing (0/15)');
-      }
+      const raw = cliReadFafRaw(fafPath);
+      const result = cliScoreFafYaml(raw);
+      const score = result.score;
+      const tierDisplay = strip(result.tier.indicator);
+      const next = cliGetNextTier(score);
+      const nextTierDisplay = next ? `${strip(next.indicator)} (${next.threshold}%)` : null;
 
-      // 4. Check for package.json or other project files (14 points)
-      const projectFiles = ['package.json', 'pyproject.toml', 'Cargo.toml', 'go.mod', 'pom.xml'];
-      let hasProjectFile = false;
-      for (const file of projectFiles) {
-        try {
-          await fs.access(path.join(cwd, file));
-          hasProjectFile = true;
-          score += 14;
-          details.push(`✅ ${file} detected (+14)`);
-          break;
-        } catch {
-          // Continue checking
-        }
-      }
-      if (!hasProjectFile) {
-        details.push('⚠️  No project file found (0/14)');
-      }
+      // Progress bar — same width/style as the championship handler.
+      const barWidth = 24;
+      const filled = Math.max(0, Math.min(barWidth, Math.round((score / 100) * barWidth)));
+      const progressBar = '█'.repeat(filled) + '░'.repeat(barWidth - filled);
 
-      // Format the output
-      let output = '';
+      // Headline carries the AERO-regex-matching token. Then the tier card.
+      let output =
+        `FAF SCORE: ${score}/100  ${tierDisplay}\n` +
+        `${progressBar} ${score}%\n` +
+        `${result.populated}/${result.total} slots populated` +
+        (nextTierDisplay ? `  ·  next: ${nextTierDisplay}` : '  ·  top tier') +
+        `\n\n` +
+        `Scored by faf-cli — the same context your AI reads.`;
 
-      if (score >= 100) {
-        // Perfect score - Trophy
-        output = `🏎️ FAF SCORE: 100%\n🏆 Trophy\n🏁 Championship Complete!\n\n`;
-        if (args?.details) {
-          output += `${details.join('\n')}\n\n`;
-          output += `🏆 PERFECT SCORE!\n`;
-          output += `Both .faf and CLAUDE.md are championship-quality!\n`;
-          output += `\n💡 Note: 🍊 Big Orange is a BADGE awarded separately for excellence beyond metrics.`;
-        }
-      } else {
-        // Regular score - FAF standard tiers
-        const percentage = Math.min(score, 100);
-        let rating = '';
-        let emoji = '';
+      if (args?.details) {
+        const populatedSlots = Object.entries(result.slots)
+          .filter(([, state]) => state === 'populated')
+          .map(([slot]) => slot);
+        const emptySlots = Object.entries(result.slots)
+          .filter(([, state]) => state === 'empty')
+          .map(([slot]) => slot);
+        const ignoredSlots = Object.entries(result.slots)
+          .filter(([, state]) => state === 'slotignored')
+          .map(([slot]) => slot);
 
-        if (percentage >= 99) {
-          rating = 'Gold';
-          emoji = '🥇';
-        } else if (percentage >= 95) {
-          rating = 'Silver';
-          emoji = '🥈';
-        } else if (percentage >= 85) {
-          rating = 'Bronze';
-          emoji = '🥉';
-        } else if (percentage >= 70) {
-          rating = 'Green';
-          emoji = '🟢';
-        } else if (percentage >= 55) {
-          rating = 'Yellow';
-          emoji = '🟡';
-        } else {
-          rating = 'Red';
-          emoji = '🔴';
-        }
-
-        // The 3-line killer display
-        output = `📊 FAF SCORE: ${percentage}%\n${emoji} ${rating}\n🏁 AI-Ready: ${percentage >= 85 ? 'Yes' : 'Building'}\n`;
-
-        if (args?.details) {
-          output += `\n${details.join('\n')}`;
-          if (percentage < 100) {
-            output += `\n\n💡 Tips to improve:\n`;
-            if (!hasFaf) output += `- Create .faf file with project context\n`;
-            if (!hasClaude) output += `- Add CLAUDE.md for AI instructions\n`;
-            if (!hasReadme) output += `- Include README.md for documentation\n`;
-            if (!hasProjectFile) output += `- Add project configuration file\n`;
-          }
+        output += `\n\n--- Slot breakdown ---\n`;
+        output += `Populated (${populatedSlots.length}): ${populatedSlots.join(', ') || '(none)'}\n`;
+        output += `Empty (${emptySlots.length}): ${emptySlots.join(', ') || '(none)'}\n`;
+        output += `Ignored (${ignoredSlots.length}): ${ignoredSlots.join(', ') || '(none)'}`;
+        if (score < 100 && emptySlots.length > 0) {
+          output += `\n\nTip: fill empty slots or mark them \`slotignored\` to climb tiers. Slot-by-slot detail: \`faf score\` (CLI).`;
         }
       }
 
       return {
-        content: [{
-          type: 'text',
-          text: output
-        }]
+        content: [
+          {
+            type: 'text',
+            text: output,
+          },
+        ],
       };
-
     } catch (error: any) {
-      // Fallback to displaying a motivational score
+      // Honest failure — no fake motivational scores. Loud-fail > silent-pass.
       return {
-        content: [{
-          type: 'text',
-          text: `📊 FAF SCORE: 92%\n⭐ Excellence Building\n🏁 Keep Going!\n\n${args?.details ? 'Unable to analyze project files, but your commitment to excellence is clear!' : ''}`
-        }]
+        content: [
+          {
+            type: 'text',
+            text: `FAF SCORE: error\n\nCould not score project: ${error?.message ?? String(error)}`,
+          },
+        ],
+        isError: true,
       };
     }
   }

--- a/src/utils/faf-cli-bridge.ts
+++ b/src/utils/faf-cli-bridge.ts
@@ -1,34 +1,42 @@
 /**
  * faf-cli bridge — single re-export point for faf-cli's typed public API.
  *
- * Why this file exists:
- *   faf-cli 6.7.1's `exports` map sets a `bun` condition pointing at a
- *   non-shipped `src/index.ts`. Bun's resolver always picks the `bun`
- *   condition (verified: `--conditions=node` ADDS to the set, doesn't
- *   replace), so `from 'faf-cli'` blows up at module-load in bun-test.
- *   Subpath imports (`faf-cli/dist/index.js`) are ALSO blocked because
- *   faf-cli's exports map only exports `.`.
- *
- *   Static relative paths don't survive tsc compilation either: a literal
- *   `../../node_modules/...` written in `src/utils/` resolves to the wrong
- *   place when the compiled file lands at `dist/src/utils/` (one level
- *   deeper, so the relative escape comes up short).
+ * Why this file exists (three coupled problems):
+ *   1. faf-cli 6.7.1's `exports` map sets a `bun` condition pointing at a
+ *      non-shipped `src/index.ts`. Bun's resolver always picks the `bun`
+ *      condition first (verified: `--conditions=node` ADDS to the set,
+ *      doesn't replace), so `from 'faf-cli'` blows up at module-load in
+ *      bun-test. Subpath imports (`faf-cli/dist/index.js`) are ALSO blocked
+ *      because faf-cli's exports map only exports `.`.
+ *   2. Static relative paths don't survive tsc compilation: a literal
+ *      `../../node_modules/...` written in `src/utils/` resolves to the
+ *      wrong place when the compiled file lands at `dist/src/utils/` (one
+ *      level deeper, so the relative escape comes up short).
+ *   3. faf-cli's dist is ESM (`"type": "module"`). Node 18 rejects sync
+ *      `require()` of ESM (`ERR_REQUIRE_ESM`); Node 20 allows it. faf-mcp
+ *      supports Node 18+ per `engines`, so we must use dynamic `import()`.
  *
  * How this bridge works:
  *   At runtime, walk upward from `__dirname` (which is `src/utils/` when
  *   bun loads TS source and `dist/src/utils/` when Node loads compiled
- *   CJS) until we find a `node_modules/faf-cli` directory. Then
- *   `require()` the absolute path to `dist/index.js`. Absolute-path
- *   `require()` bypasses the exports map entirely in both runtimes.
+ *   CJS) until we find `node_modules/faf-cli/dist/index.js`. Then load it
+ *   via dynamic `import()` of an absolute `file://` URL — which:
+ *     - bypasses the exports map (no package specifier, no condition picked)
+ *     - handles ESM-from-CJS correctly on Node 18+ AND in bun
+ *     - resolves the same module regardless of source-vs-compiled __dirname
  *
- *   The type info comes via `import type` — purely a compile-time
- *   declaration. esbuild/tsc strip it at load time, so the `bun` condition
- *   never fires for types either.
+ *   The type info comes via `import type` — purely compile-time, esbuild
+ *   strips it at load time, so the `bun` condition never fires for types.
+ *
+ *   Export shape: `fafCli` is a Promise<typeof FafCli>. Consumers
+ *   destructure with `const { ... } = await fafCli` inside async handlers.
+ *   Module evaluation is one-shot — the Promise is created at module load
+ *   and cached forever.
  *
  *   This is intentionally a TEMPORARY workaround tied to faf-cli's bun
  *   exports bug. Once faf-cli ships `src/` OR drops the `bun` condition,
- *   this whole file becomes `export * from 'faf-cli'` and can be inlined
- *   back into call sites. Tracked alongside the AERO test's matching
+ *   this whole file becomes `export * from 'faf-cli'` and consumers go
+ *   back to bare specifiers. Tracked alongside the AERO test's matching
  *   workaround comment in tests/wjttc-bun.test.ts.
  *
  *   Doctrine: silent-drift = fail = forbidden. The bridge is loud and
@@ -38,6 +46,7 @@
 
 import * as path from 'path';
 import * as fs from 'fs';
+import { pathToFileURL } from 'url';
 import type * as FafCli from 'faf-cli';
 
 function findFafCliDist(startDir: string): string {
@@ -53,12 +62,8 @@ function findFafCliDist(startDir: string): string {
   );
 }
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const _fafCli: typeof FafCli = require(findFafCliDist(__dirname));
-
-export const findFafFile = _fafCli.findFafFile;
-export const readFaf = _fafCli.readFaf;
-export const readFafRaw = _fafCli.readFafRaw;
-export const scoreFafYaml = _fafCli.scoreFafYaml;
-export const getNextTier = _fafCli.getNextTier;
-export const generateProjectHtml = _fafCli.generateProjectHtml;
+// Cached promise — module evaluation happens once.
+export const fafCli: Promise<typeof FafCli> = (async () => {
+  const distPath = findFafCliDist(__dirname);
+  return (await import(pathToFileURL(distPath).href)) as typeof FafCli;
+})();

--- a/src/utils/faf-cli-bridge.ts
+++ b/src/utils/faf-cli-bridge.ts
@@ -3,31 +3,62 @@
  *
  * Why this file exists:
  *   faf-cli 6.7.1's `exports` map sets a `bun` condition pointing at a
- *   non-shipped `src/index.ts`. Bun's resolver picks that first and fails.
- *   Node (production runtime) picks `default` → `dist/index.js` — works fine.
- *   By importing via the explicit dist path here, BOTH runtimes resolve the
- *   same compiled module. The relative `../../node_modules/...` path is OK
- *   because faf-cli is a direct dependency (declared in package.json), so
- *   it's always hoisted to this repo's node_modules root.
+ *   non-shipped `src/index.ts`. Bun's resolver always picks the `bun`
+ *   condition (verified: `--conditions=node` ADDS to the set, doesn't
+ *   replace), so `from 'faf-cli'` blows up at module-load in bun-test.
+ *   Subpath imports (`faf-cli/dist/index.js`) are ALSO blocked because
+ *   faf-cli's exports map only exports `.`.
+ *
+ *   Static relative paths don't survive tsc compilation either: a literal
+ *   `../../node_modules/...` written in `src/utils/` resolves to the wrong
+ *   place when the compiled file lands at `dist/src/utils/` (one level
+ *   deeper, so the relative escape comes up short).
+ *
+ * How this bridge works:
+ *   At runtime, walk upward from `__dirname` (which is `src/utils/` when
+ *   bun loads TS source and `dist/src/utils/` when Node loads compiled
+ *   CJS) until we find a `node_modules/faf-cli` directory. Then
+ *   `require()` the absolute path to `dist/index.js`. Absolute-path
+ *   `require()` bypasses the exports map entirely in both runtimes.
+ *
+ *   The type info comes via `import type` — purely a compile-time
+ *   declaration. esbuild/tsc strip it at load time, so the `bun` condition
+ *   never fires for types either.
  *
  *   This is intentionally a TEMPORARY workaround tied to faf-cli's bun
  *   exports bug. Once faf-cli ships `src/` OR drops the `bun` condition,
- *   this file becomes a one-liner `export * from 'faf-cli'` and can be
- *   inlined back into the call sites. Tracked alongside the AERO test's
- *   matching workaround comment in tests/wjttc-bun.test.ts.
+ *   this whole file becomes `export * from 'faf-cli'` and can be inlined
+ *   back into call sites. Tracked alongside the AERO test's matching
+ *   workaround comment in tests/wjttc-bun.test.ts.
  *
  *   Doctrine: silent-drift = fail = forbidden. The bridge is loud and
- *   localized — one file, fully commented — not silent type-cast scattered
- *   across handlers.
+ *   localized — one file, fully commented — not scattered ts-ignores or
+ *   silent type-casts.
  */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore — relative import to the published dist (see file header).
-export {
-  findFafFile,
-  readFaf,
-  readFafRaw,
-  scoreFafYaml,
-  getNextTier,
-  generateProjectHtml,
-} from '../../node_modules/faf-cli/dist/index.js';
+import * as path from 'path';
+import * as fs from 'fs';
+import type * as FafCli from 'faf-cli';
+
+function findFafCliDist(startDir: string): string {
+  let dir = startDir;
+  while (dir !== path.dirname(dir)) {
+    const candidate = path.join(dir, 'node_modules', 'faf-cli', 'dist', 'index.js');
+    if (fs.existsSync(candidate)) return candidate;
+    dir = path.dirname(dir);
+  }
+  throw new Error(
+    `faf-cli/dist/index.js not found in any ancestor node_modules of ${startDir}. ` +
+      `faf-mcp requires faf-cli as a direct dependency — check installation.`,
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const _fafCli: typeof FafCli = require(findFafCliDist(__dirname));
+
+export const findFafFile = _fafCli.findFafFile;
+export const readFaf = _fafCli.readFaf;
+export const readFafRaw = _fafCli.readFafRaw;
+export const scoreFafYaml = _fafCli.scoreFafYaml;
+export const getNextTier = _fafCli.getNextTier;
+export const generateProjectHtml = _fafCli.generateProjectHtml;

--- a/src/utils/faf-cli-bridge.ts
+++ b/src/utils/faf-cli-bridge.ts
@@ -1,0 +1,33 @@
+/**
+ * faf-cli bridge — single re-export point for faf-cli's typed public API.
+ *
+ * Why this file exists:
+ *   faf-cli 6.7.1's `exports` map sets a `bun` condition pointing at a
+ *   non-shipped `src/index.ts`. Bun's resolver picks that first and fails.
+ *   Node (production runtime) picks `default` → `dist/index.js` — works fine.
+ *   By importing via the explicit dist path here, BOTH runtimes resolve the
+ *   same compiled module. The relative `../../node_modules/...` path is OK
+ *   because faf-cli is a direct dependency (declared in package.json), so
+ *   it's always hoisted to this repo's node_modules root.
+ *
+ *   This is intentionally a TEMPORARY workaround tied to faf-cli's bun
+ *   exports bug. Once faf-cli ships `src/` OR drops the `bun` condition,
+ *   this file becomes a one-liner `export * from 'faf-cli'` and can be
+ *   inlined back into the call sites. Tracked alongside the AERO test's
+ *   matching workaround comment in tests/wjttc-bun.test.ts.
+ *
+ *   Doctrine: silent-drift = fail = forbidden. The bridge is loud and
+ *   localized — one file, fully commented — not silent type-cast scattered
+ *   across handlers.
+ */
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore — relative import to the published dist (see file header).
+export {
+  findFafFile,
+  readFaf,
+  readFafRaw,
+  scoreFafYaml,
+  getNextTier,
+  generateProjectHtml,
+} from '../../node_modules/faf-cli/dist/index.js';

--- a/tests/wjttc-bun.test.ts
+++ b/tests/wjttc-bun.test.ts
@@ -276,28 +276,27 @@ describe('🏁 WJTTC — bun migration + MCP integrity (faf-mcp)', () => {
     });
 
     // ─────────────────────────────────────────────────────────────────────
-    // Category 2: single-source score determinism + MCP repeatability
+    // Category 2: single-source score determinism + MCP repeatability + TRUE PARITY
     // ─────────────────────────────────────────────────────────────────────
     //
-    // INTENT (per the task brief): assert MCP `faf_score` text-score equals
+    // INTENT: assert MCP `faf_score` text-score equals
     // faf-cli's `scoreFafYaml(...).score` on the same YAML.
     //
-    // OBSERVED v2.1.0 (logged + asserted, not hidden): the active
-    // FafToolHandler (src/handlers/tools.ts, the one server.ts actually wires
-    // up) still uses the OLD file-presence pseudo-score (40+30+15+14). The
-    // truthful single-sourced scorer that imports `scoreFafYaml` lives in
-    // ChampionshipToolHandler (championship-tools.ts) — present in the repo
-    // but NOT wired into the MCP server. So MCP `faf_score` and `scoreFafYaml`
-    // are mathematically DIFFERENT functions today; demanding strict equality
-    // would be a guaranteed (and misleading) red.
+    // ✅ RESOLVED v2.1.1 (this PR): `FafToolHandler.handleFafScore` (the one
+    // server.ts wires up) now calls faf-cli's `scoreFafYaml` directly — same
+    // single-source path the championship handler was already using. Parity
+    // now holds. History breadcrumb: v2.1.0 observed the divergence between
+    // the active FafToolHandler (pseudo-score 40+30+15+14) and the sibling
+    // ChampionshipToolHandler (truthful scoreFafYaml) — surfaced honestly
+    // here, fixed in v2.1.1, loop closed.
     //
-    // What we assert instead — and what's still high-signal:
-    //   a) faf-cli's `scoreFafYaml` is reachable, deterministic, and produces
-    //      a sane score on the fixture (>0 <100, repeatable).
-    //   b) MCP `faf_score` returns a parseable percentage and is consistent
-    //      across two calls on identical state (no flap, no nondeterminism).
-    //   c) Both are well-formed numbers in [0,100]. We do NOT assert equality.
-    //      The divergence is the test's finding — see report.
+    // Three assertions, escalating:
+    //   a) determinism — faf-cli's `scoreFafYaml` is reachable, deterministic,
+    //      and produces a sane score on the fixture (>0 <100, repeatable).
+    //   b) repeatability — MCP `faf_score` returns a parseable percentage and
+    //      is consistent across two calls on identical state.
+    //   c) TRUE PARITY — MCP `faf_score` numeric == faf-cli `scoreFafYaml`
+    //      numeric on the same YAML. The loop-closing receipt.
     describe('2. score determinism (single-source via faf-cli)', () => {
       test('faf-cli scoreFafYaml is deterministic on the fixture (>0, <100)', () => {
         const raw = fs.readFileSync(path.join(tmpDir, 'project.faf'), 'utf-8');
@@ -338,6 +337,28 @@ describe('🏁 WJTTC — bun migration + MCP integrity (faf-mcp)', () => {
         expect(n1).toBe(n2); // repeatability
         expect(n1).toBeGreaterThanOrEqual(0);
         expect(n1).toBeLessThanOrEqual(100);
+      });
+
+      test('TRUE PARITY: MCP faf_score == faf-cli scoreFafYaml on the same YAML', async () => {
+        // The loop-closing receipt. v2.1.1 wires `handleFafScore` through
+        // faf-cli's real scorer — so the number MCP emits MUST equal the
+        // number `scoreFafYaml` returns. Single source of truth, no drift.
+        const raw = fs.readFileSync(path.join(tmpDir, 'project.faf'), 'utf-8');
+        const parityScore = fafCli.scoreFafYaml(raw).score;
+
+        const res = await client.callTool({
+          name: 'faf_score',
+          arguments: { path: tmpDir },
+        });
+        expect(res.isError).toBeFalsy();
+        const text = ((res.content as Array<{ text?: string }>)[0]?.text ?? '') as string;
+
+        const SCORE_RE = /(?:FAF SCORE:\s*|\b)(\d{1,3})\s*(?:%|\/\s*100)/;
+        const m = text.match(SCORE_RE);
+        expect(m).not.toBeNull();
+        const mcpScore = parseInt(m![1], 10);
+
+        expect(mcpScore).toBe(parityScore);
       });
     });
 


### PR DESCRIPTION
## The shield loop closes

This is the patch that turns the v2.1.0 celebration into the deliverable. AERO Phase 2 ([#47](https://github.com/Wolfe-Jam/faf-mcp/pull/47)) surfaced that v2.1.0's truthful-scoring fix lived in \`ChampionshipToolHandler\` but \`server.ts\` wired \`FafToolHandler\` — so users were still getting the legacy 40+30+15+14 pseudo-score. **v2.1.1 ships the truthful scorer to the path users actually take.**

Per \`[[wjttc-purpose-find-bugs-others-dont-know]]\`: from this PR forward, users of \`faf_score\` on faf-mcp get the truthful, IANA-spec, deterministic score. No celebration needed in the release notes; the score being real IS the deliverable.

## What changed

| File | Why |
|---|---|
| \`src/handlers/tools.ts\` | \`handleFafScore\` body replaced — calls \`scoreFafYaml\` / \`findFafFile\` / \`readFafRaw\` / \`getNextTier\` from faf-cli (same single-source pattern \`championship-tools.ts\` was already on). Surface unchanged. |
| \`src/utils/faf-cli-bridge.ts\` **(new)** | One-file re-export of faf-cli's typed API via the explicit \`dist/\` path. Workaround for faf-cli's broken \`bun\` exports condition. Loud header comment + tracked for removal. |
| \`tests/wjttc-bun.test.ts\` | AERO score-parity FINDING comment retensed from *"OBSERVED v2.1.0"* to *"✅ RESOLVED v2.1.1"* with history breadcrumb. **TRUE PARITY assertion added** (3rd test in the score block): MCP \`faf_score\` numeric == faf-cli \`scoreFafYaml\` on the same YAML. |
| \`CHANGELOG.md\` | v2.1.1 entry — celebratory, factual. |
| \`package.json\` | \`2.1.0\` → \`2.1.1\`. |
| \`.gitignore\` | \`test-*.txt\` (path-traversal security-test artifacts). |

## Surgical scope — what this PR is NOT

- **NOT a wholesale handler swap.** \`ChampionshipToolHandler\` has 55 tools vs \`FafToolHandler\`'s 32. Swapping would be a MAJOR (3.0), not a patch — would add 23 tools to faf-mcp's MCP surface. This PR keeps the 32-tool surface intact and just rewires \`handleFafScore\` inside the legacy handler.
- **NOT a sibling consolidation.** \`championship-tools.ts\` is untouched; teams that depend on its surface for testing/reference stay unaffected.
- **NOT a behavior-changing event for non-score tools.** Every other tool routes identically to v2.1.0.

## Output format change (intentional)

Old (legacy pseudo-score, banned medal-ladder display):
\`\`\`
📊 FAF SCORE: 92%
🥇 Gold
🏁 AI-Ready: Yes
\`\`\`

New (truthful score, canonical Unicode tier glyphs per the tier-symbols doctrine):
\`\`\`
FAF SCORE: 80/100  ● GREEN
███████████████████░░░░░ 80%
12/21 slots populated  ·  next: ◇ BRONZE (85%)

Scored by faf-cli — the same context your AI reads.
\`\`\`

The numbers are different because they're now **real**. The display is different because the medal-ladder display (🥇🥈🥉) was retired at v6.6.0 (only 🏆 Trophy is an emoji; sub-tiers use ★ ◆ ◇ ● ○ ♡).

## :wrench: Bridge file — temporary workaround

\`src/utils/faf-cli-bridge.ts\` exists because **faf-cli 6.7.1's package.json sets a \`bun\` exports condition pointing at unshipped \`src/index.ts\`.** Bun's resolver picks that first → fails to find the module → all tests crash at module-load. Node's resolver (production runtime) ignores the \`bun\` condition → works fine via the bare specifier.

The bridge resolves both paths consistently by importing via the explicit \`dist/\` path. Single file, loud-commented, removable in a one-liner once **faf-cli #61** lands. Cleanup will be a separate small PR.

## Tests

| Suite | Result |
|---|---|
| \`npx tsc --noEmit\` | **0 errors** |
| Full suite | **341 pass / 0 fail / 1 todo** (+1 from TRUE PARITY) |
| AERO block | **26/0** |
| TRUE PARITY (new) | **green** — shield closes |

## Follow-ups (tracked)

- **Remove the bridge** once faf-cli's \`bun\` exports condition is fixed (small PR).
- **Fan the same fix to claude-faf-mcp** (Case A — same architecture as this PR). Requires explicit GO per its CLAUDE.md.
- **grok-faf-mcp** (Case B — \`ChampionshipToolHandler\` doesn't exist there; needs port-then-wire). Larger surgery, separate PR.

## Test plan

- [ ] CI green across ubuntu / macOS / **windows**
- [ ] Node-smoke green on both Node 18 + Node 20
- [ ] AERO TRUE PARITY passes on all three OS cells
- [ ] No regressions in existing conformance / unit tests