### PR TITLE
docs: add FAF Trophy badge to README (pilot for cohort sweep)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   </div>
 </div>
 
+[![FAF Trophy 100%](https://img.shields.io/badge/FAF-%F0%9F%8F%86%20100%25-000000?labelColor=FF6B35)](https://faf.one)
 [![IANA: vnd.faf+yaml](https://img.shields.io/badge/IANA-vnd.faf%2Byaml-00D4D4)](https://www.iana.org/assignments/media-types/application/vnd.faf+yaml)
 [![DOI: Context paper](https://img.shields.io/badge/DOI-Context%20paper-FF6B35)](https://doi.org/10.5281/zenodo.18251362)
 


### PR DESCRIPTION
**Pilot for task #65.** Badge design per wolfejam spec: white text on orange (FAF brand) → white text on black (Trophy 100%). No other colors.

Markdown:
```md
[![FAF Trophy 100%](https://img.shields.io/badge/FAF-%F0%9F%8F%86%20100%25-000000?labelColor=FF6B35)](https://faf.one)
```

Rendered: ![FAF Trophy 100%](https://img.shields.io/badge/FAF-%F0%9F%8F%86%20100%25-000000?labelColor=FF6B35)

**Doctrine alignment:** Trophy is the only releasable state for FAF-family packages (per CLAUDE.md / pubpro FAF Gate). So this badge is effectively a release-gate stamp — every released FAF repo earns it. Sub-Trophy states (`FAF 88%` etc.) only exist in dev branches, not on shipped main, so no other colors needed.

**Next:** if approved, fan to faf-cli, claude-faf-mcp, grok-faf-mcp, gemini-faf-mcp, WJTTC, faf-scoring-kernel (one verbatim PR per repo, cohort-symmetric).