### PR TITLE
docs: bunx config in Quick Start + Three Ways to Deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ You maintain `.cursorrules`. Your teammate uses `AGENTS.md`. Someone on the team
 ### Quick Start
 
 ```bash
-npx faf-mcp
+bunx faf-mcp
 ```
 
 Add to your MCP config:
 
 ```json
-{"mcpServers": {"faf": {"command": "npx", "args": ["-y", "faf-mcp"]}}}
+{"mcpServers": {"faf": {"command": "bunx", "args": ["faf-mcp"]}}}
 ```
 
 | Platform | Config File |
@@ -67,7 +67,7 @@ Add to your MCP config:
 |------|--------|----------|
 | **Hosted** | [mcpaas.live](https://mcpaas.live) | Zero-install, point any MCP client to the URL |
 | **Self-Deploy** | [Deploy to Vercel](https://vercel.com/new?repository-url=https://github.com/Wolfe-Jam/faf-mcp) | Your own instance, full control |
-| **Local** | `npx faf-mcp` | IDE integration via stdio transport |
+| **Local** | `bunx faf-mcp` | IDE integration via stdio transport |
 
 ### Hosted (mcpaas.live)
 


### PR DESCRIPTION
## Why

Cohort-wide sweep — bunx leads in proof-card configs across the three FAF MCPs.

This is the **smaller end** of the cohort sweep. `faf-mcp`'s hosted recommendation (`mcpaas.live`) is on Cloudflare Workers and was verified live this session (HTTP 200 in 679ms, SSE GET returns 63 bytes). That recommendation stays — only the local-launch examples needed the bunx swap.

The other two FAF MCPs (`grok-faf-mcp`, `claude-faf-mcp`) had bigger fixes because their hosted recommendations pointed at Vercel deploys that are currently hanging (HTTP 000 at root + `/sse`). This repo's recommendation points elsewhere, so no removal needed here.

## What

- `bash`: `npx faf-mcp` → `bunx faf-mcp`
- JSON: `command: "npx", args: ["-y", ...]` → `command: "bunx", args: [...]`
- 'Three Ways to Deploy' Local row: `npx faf-mcp` → `bunx faf-mcp`

`bunx faf-mcp` verified working locally — server holds stdio open past 3s, initial output: `Resolving dependencies / Resolved, downloaded and extracted [242]`. Empirical perf delta from the cohort bench: bunx warm-start ~2s vs npx ~10s (5× wall-clock, 26× CPU).

## Cohort

- `grok-faf-mcp`: shipped direct to main via `5c5c7d1` (larger scope — removed Hosted section + Endpoints table)
- `claude-faf-mcp`: PR #66 (removed broken Web install command pointing at hanging Vercel SSE)
- `faf-mcp`: **this PR**

Doctrine: [[silent-drift-equals-fail-equals-forbidden]] applied at the README-leads-with-broken-default layer. `mcpaas.live` continues to be the right hosted recommendation here because it's measurably live (not based on "probably works" — measured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)