### PR TITLE
chore(security): rotate legacy admin token in cloud-handler

### DIFF
--- a/src/handlers/cloud-handler.ts
+++ b/src/handlers/cloud-handler.ts
@@ -19,7 +19,7 @@ const MCPAAS_API = 'https://mcpaas.live/mcp';
 const MCPAAS_SOULS_BASE = 'https://mcpaas.live/souls';
 
 // Legacy auth token (will transition to OAuth)
-const DEFAULT_TOKEN = process.env.MCPAAS_TOKEN || 'wolfe-68-orange';
+const DEFAULT_TOKEN = process.env.MCPAAS_TOKEN || 'wolfe-77-red';
 
 interface McpRequest {
   jsonrpc: '2.0';


### PR DESCRIPTION
## Why

Companion to **mcpaas-cf PR #4** (legacy token rotation). The `DEFAULT_TOKEN` fallback in this package's cloud-handler also references the old `wolfe-68-orange` — rotates to `wolfe-77-red` in lockstep so this package's cloud calls continue to work against the new mcpaas-cf production.

## What changed

One line in `src/handlers/cloud-handler.ts`:

```diff
- const DEFAULT_TOKEN = process.env.MCPAAS_TOKEN || 'wolfe-68-orange';
+ const DEFAULT_TOKEN = process.env.MCPAAS_TOKEN || 'wolfe-77-red';
```

`MCPAAS_TOKEN` environment variable continues to take precedence — this is just the in-source fallback.

## Sequence

1. Merge mcpaas-cf PR #4 + `wrangler deploy` (production gets the new token)
2. Merge this PR (faf-mcp's cloud-handler fallback aligns)
3. wolfejam updates `~/.grok/config.toml` bearer
4. Verify: any caller using `Bearer wolfe-77-red` succeeds; old token rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)