### PR TITLE
chore(ci): bump faf-taf-git → v2.2.0, drop bun→jest shim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,22 +81,9 @@ jobs:
           flags: unittests
           name: codecov-umbrella
 
-      - name: Convert bun output to Jest format for TAF
-        if: matrix.os == 'ubuntu-latest' && github.event_name == 'push'
-        shell: bash
-        run: |
-          passed=$(grep -oE '^[[:space:]]*[0-9]+ pass' /tmp/test-output.txt | grep -oE '[0-9]+' | head -1 || echo 0)
-          failed=$(grep -oE '^[[:space:]]*[0-9]+ fail' /tmp/test-output.txt | grep -oE '[0-9]+' | head -1 || echo 0)
-          total=$((passed + failed))
-          if [ "$failed" -gt 0 ]; then
-            echo "Tests: $failed failed, $passed passed, $total total" >> /tmp/test-output.txt
-          else
-            echo "Tests: $passed passed, $total total" >> /tmp/test-output.txt
-          fi
-
       - name: Generate TAF Receipt
         if: matrix.os == 'ubuntu-latest' && github.event_name == 'push'
-        uses: Wolfe-Jam/faf-taf-git@v2.1.2
+        uses: Wolfe-Jam/faf-taf-git@v2.2.0
         with:
           test-output-file: /tmp/test-output.txt
           auto-commit: 'true'


### PR DESCRIPTION
## What

Bumps `Wolfe-Jam/faf-taf-git@v2.1.2` → `@v2.2.0` and removes the `Convert bun output to Jest format for TAF` shim step from `ci.yml`.

## Why

`v2.2.0` ships a native bun-test parser (`src/parsers/bun.ts`) that reads bun's `Ran N tests across M files` line directly. The shim is no longer needed — and it was undercounting (`total = passed + failed`, missing `skip + todo`).

## Diff

`-12 lines` (shim step), `+0 lines`. Test logic, matrix, upload-coverage, all unchanged.

## Cohort

Sister PRs in the same sweep: [Wolfe-Jam/grok-faf-mcp#76](https://github.com/Wolfe-Jam/grok-faf-mcp/pull/76) · [Wolfe-Jam/claude-faf-mcp#68](https://github.com/Wolfe-Jam/claude-faf-mcp/pull/68).

## Origin

`grok-faf-mcp` 1.4.9 dress rehearsal surfaced `.taf` recording `232/232` for a run reported as `Ran 234`. Closed in [Wolfe-Jam/faf-taf-git#2](https://github.com/Wolfe-Jam/faf-taf-git/pull/2) → [v2.2.0](https://github.com/Wolfe-Jam/faf-taf-git/releases/tag/v2.2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)