### PR TITLE
fix(mcp): stdio capability completeness (v2.1.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- faf: faf-mcp | TypeScript | mcp-server | FAF MCP IDE Edition — persistent project context for Cursor, Windsurf, Cline, VS Code -->
-<!-- faf: doc=changelog | latest=v2.1.1 | canonical=project.faf | family=FAF -->
+<!-- faf: doc=changelog | latest=v2.1.2 | canonical=project.faf | family=FAF -->
 
 # Changelog
 
@@ -7,6 +7,22 @@ All notable changes to faf-mcp will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.1.2] - 2026-06-08
+
+MCP capability completeness — the stdio server now answers every capability it
+advertises. Strict clients (Cursor, Windsurf, Cline) and Glama's Inspector probe
+each advertised capability; a `-32601` flags the server even when tools work.
+
+### Fixed
+
+- **`resources/templates/list` now returns `{ resourceTemplates: [] }`** instead
+  of `-32601`. Registered `ListResourceTemplatesRequestSchema` (`src/server.ts`).
+- **Dropped unbacked `subscribe: true`** from the advertised `resources`
+  capability (no subscribe handler exists) → `resources: { listChanged: true }`.
+  `/info` payload aligned.
+
+No tool changes. Also added `glama.json` for explicit directory metadata.
 
 ## [2.1.1] - 2026-05-26
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "faf-mcp",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "mcpName": "io.github.Wolfe-Jam/faf-mcp",
   "description": "Persistent Project Context for Cursor, IDEs and VS Code. IANA-registered .faf format, 25 MCP tools, 309 tests.",
   "icon": "./assets/icons/faf-icon-256.png",
   "logo": "./assets/icons/faf-icon-256.png",
-  "displayName": ".faf \ud83d\udc18",
+  "displayName": ".faf 🐘",
   "main": "dist/src/index.js",
   "bin": {
     "faf-mcp": "dist/src/index.js"

--- a/server.json
+++ b/server.json
@@ -38,12 +38,12 @@
     "url": "https://github.com/Wolfe-Jam/faf-mcp",
     "source": "github"
   },
-  "version": "2.1.1",
+  "version": "2.1.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "faf-mcp",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
-import { CallToolRequestSchema, ListResourcesRequestSchema, ListToolsRequestSchema, ReadResourceRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { CallToolRequestSchema, ListResourcesRequestSchema, ListResourceTemplatesRequestSchema, ListToolsRequestSchema, ReadResourceRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { FafResourceHandler } from './handlers/resources';
 import { FafToolHandler } from './handlers/tools';
 import { FafEngineAdapter } from './handlers/engine-adapter';
@@ -41,8 +41,10 @@ export class FafMcpServer {
       },
       {
         capabilities: {
+          // No subscribe/unsubscribe handler is registered, so do NOT advertise
+          // `subscribe` — advertising it makes resources/subscribe -32601, which
+          // trips strict clients / Glama's capability health-check.
           resources: {
-            subscribe: true,
             listChanged: true,
           },
           tools: {
@@ -76,6 +78,13 @@ export class FafMcpServer {
 
     this.server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
       return this.resourceHandler.readResource(request.params.uri);
+    });
+
+    // Resource templates: none defined. The advertised `resources` capability
+    // must answer this method with a valid (empty) list rather than -32601 —
+    // strict clients and Glama's MCP Inspector probe every advertised capability.
+    this.server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
+      return { resourceTemplates: [] };
     });
 
     // Tool handlers
@@ -138,7 +147,7 @@ export class FafMcpServer {
         description: 'Universal FAF MCP Server for Claude - AI Context Intelligence & Project Enhancement',
         transport: 'http-sse',
         capabilities: {
-          resources: { subscribe: true, listChanged: true },
+          resources: { listChanged: true },
           tools: { listChanged: true }
         },
         tools: [


### PR DESCRIPTION
Advertised `resources {subscribe:true}` with **no `resources/templates/list` handler and no subscribe handler** → `-32601` on both. Strict clients (Cursor, Windsurf, Cline) + Glama's Inspector probe every advertised capability.

**Fix (`src/server.ts`):** register `ListResourceTemplatesRequestSchema` → `{ resourceTemplates: [] }`; drop unbacked `subscribe:true` → `resources: { listChanged: true }` (/info aligned).

**Verified on the stdio binary:** `caps.resources={listChanged:true}`, `resources/templates/list→{resourceTemplates:[]}`. 341 pass / 0 fail. → **v2.1.2**.

---
Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)

🤖 Generated with [Claude Code](https://claude.com/claude-code)