### PR TITLE
fix(docs): retire SSE/Vercel links + fix dead og-image

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,14 +7,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" href="https://faf.one/orange-smiley.svg" type="image/svg+xml">
   <meta property="og:title" content="MCPaaS — MCP as a Service">
-  <meta property="og:description" content="The future of MCP is Instant. 21 tools, SSE transport, any MCP client. Zero config, zero env vars.">
-  <meta property="og:image" content="https://faf.one/og-image-1200x630.png">
-  <meta property="og:url" content="https://faf-mcp.vercel.app">
+  <meta property="og:description" content="The future of MCP is Instant. 32 tools, Streamable HTTP transport, any MCP client. Zero config, zero env vars.">
+  <meta property="og:image" content="https://faf.one/orange-smiley.svg">
+  <meta property="og:url" content="https://faf.one">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="MCPaaS — MCP as a Service">
-  <meta name="twitter:description" content="The future of MCP is Instant. 21 tools, SSE transport, any MCP client.">
-  <meta name="twitter:image" content="https://faf.one/og-image-1200x630.png">
+  <meta name="twitter:description" content="The future of MCP is Instant. 32 tools, Streamable HTTP transport, any MCP client.">
+  <meta name="twitter:image" content="https://faf.one/orange-smiley.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <style>
@@ -292,7 +292,7 @@
 
         <div class="stats">
           <div class="stat">
-            <div class="stat-value">21</div>
+            <div class="stat-value">32</div>
             <div class="stat-label">MCP Tools</div>
           </div>
           <div class="stat">
@@ -334,14 +334,10 @@
     </div>
 
     <div class="three-doors">
-      <h3>Three Ways to Deploy</h3>
+      <h3>Two Ways to Deploy</h3>
       <div class="door">
         <span class="door-name">Hosted</span>
-        <span class="door-value"><a href="https://ide.faf.one/mcp/v1">ide.faf.one/mcp/v1</a> · <a href="https://ide.faf.one/sse">SSE</a></span>
-      </div>
-      <div class="door">
-        <span class="door-name">Self-Deploy</span>
-        <span class="door-value"><a href="https://vercel.com/new?repository-url=https://github.com/Wolfe-Jam/faf-mcp">Deploy to Vercel</a></span>
+        <span class="door-value"><a href="https://ide.faf.one/mcp/v1">ide.faf.one/mcp/v1</a> · Streamable HTTP</span>
       </div>
       <div class="door">
         <span class="door-name">Local</span>
@@ -350,7 +346,7 @@
     </div>
 
     <div class="bottom-bar">
-      <div class="bottom-left">v2.0.1 · IANA Registered · application/vnd.faf+yaml</div>
+      <div class="bottom-left">v2.1.2 · IANA Registered · application/vnd.faf+yaml</div>
       <div class="bottom-platforms">
         <span class="copy-cmd" data-cmd="npx claude-faf-mcp" title="Copy the install command — paste in any terminal or your AI">Claude</span><span class="dot">&bull;</span>
         <span class="copy-cmd" data-cmd="npx grok-faf-mcp" title="Copy the install command — paste in any terminal or your AI">Grok</span><span class="dot">&bull;</span>


### PR DESCRIPTION
Fixes stale and broken links on the static landing page `docs/index.html`.

## Changes
- **Dead og-image (404):** `og:image` + `twitter:image` swapped from `https://faf.one/og-image-1200x630.png` (404) to `https://faf.one/orange-smiley.svg` (verified 200).
- **Redirect shim:** `og:url` repointed from `https://faf-mcp.vercel.app` to the real home `https://faf.one` (verified 200).
- **Retired SSE link:** removed `https://ide.faf.one/sse` from the Hosted door; the live `ide.faf.one/mcp/v1` is now labelled "Streamable HTTP" (verified 200).
- **Retired Vercel self-deploy:** removed the "Deploy to Vercel" button (`vercel.com/new?...`) and its whole Self-Deploy door; heading updated "Three Ways to Deploy" → "Two Ways to Deploy".
- **Meta descriptions:** "SSE transport" → "Streamable HTTP transport".
- **Stale tool count:** "21 tools" → "32 tools" (verified via a live stdio `tools/list` against the built package — 32 tools served).
- **Stale version:** `v2.0.1` → `v2.1.2` (matches `package.json` / `server.json`).

## Verification
- `grep -nE '/sse|vercel\.com/new|faf-mcp\.vercel\.app|og-image-1200x630' docs/index.html` → no matches.
- All touched URLs curl 200 (`faf.one`, `faf.one/orange-smiley.svg`, `ide.faf.one/mcp/v1`).
- Diff eyeballed: HTML well-formed, no dangling tags from the button removal.

---
Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)

🤖 Generated with [Claude Code](https://claude.com/claude-code)