### PR TITLE
test(visibility): fix flaky perf bound (10ms→50ms) on Windows CI

### DIFF
--- a/tests/visibility.test.ts
+++ b/tests/visibility.test.ts
@@ -238,7 +238,7 @@ describe('🏎️ Tool Visibility System', () => {
   });
 
   describe('Performance', () => {
-    it('should filter tools quickly (< 10ms for 61 tools)', () => {
+    it('should filter tools quickly (< 50ms for 61 tools)', () => {
       const mockTools: Tool[] = Array.from({ length: 61 }, (_, i) => ({
         name: `tool_${i}`,
         description: 'Test tool',
@@ -249,7 +249,10 @@ describe('🏎️ Tool Visibility System', () => {
       filterTools(mockTools, false);
       const duration = Date.now() - start;
 
-      expect(duration).toBeLessThan(10);
+      // Filtering 61 tools is sub-millisecond; the bound only guards against a
+      // real regression. Date.now() has ~15ms resolution on Windows runners, so
+      // a <10ms wall-clock assertion is unreliable there — 50ms is the regression gate.
+      expect(duration).toBeLessThan(50);
     });
   });
 });


### PR DESCRIPTION
## What

Loosen the wall-clock perf assertion in `tests/visibility.test.ts` from `<10ms` to `<50ms`.

## Why

`Date.now()` has ~15ms resolution on Windows CI runners, so the sub-10ms bound fails intermittently regardless of real speed (observed **14ms** on `windows-latest`). Filtering 61 tools is sub-millisecond — 50ms is the genuine regression gate.

## Unblocks

This flaky test — **not** the dependency — is what reds **#37** (codecov-action 5→6). On that run the test step failed first, so the coverage step (and codecov v6) was *skipped* and never even ran. Landing this lets #37 rebase green.

Verified locally: `bun test tests/visibility.test.ts` → 22 pass / 0 fail.

---
Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)