### PR TITLE
fix(docs): version-placement doctrine — single dynamic top-left badge + Edition-Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   </div>
 </div>
 
+[![npm](https://img.shields.io/npm/v/faf-mcp?color=00CCFF)](https://www.npmjs.com/package/faf-mcp)
 [![FAF Trophy 100%](https://img.shields.io/badge/FAF-%F0%9F%8F%86%20100%25-000000?labelColor=FF6B35)](https://faf.one)
 [![IANA: vnd.faf+yaml](https://img.shields.io/badge/IANA-vnd.faf%2Byaml-00D4D4)](https://www.iana.org/assignments/media-types/application/vnd.faf+yaml)
 [![DOI: Context paper](https://img.shields.io/badge/DOI-Context%20paper-FF6B35)](https://doi.org/10.5281/zenodo.18251362)
@@ -18,7 +19,6 @@
 The MCP you didn't realise you needed, or wanted but didn't know who to ask, is here. Building on 62,000+ downloads across the FAF ecosystem, we bring you faf-mcp to cure your syncing pain and fuel your chosen AI with optimized context, on-demand.
 
 [![CI](https://github.com/Wolfe-Jam/faf-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/Wolfe-Jam/faf-mcp/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/npm/v/faf-mcp?color=00CCFF)](https://www.npmjs.com/package/faf-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![project.faf](https://img.shields.io/badge/project.faf-inside-00D4D4)](https://github.com/Wolfe-Jam/faf)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -280,6 +280,7 @@
   </style>
 </head>
 <body>
+  <a id="versionBadge" href="https://github.com/Wolfe-Jam/faf-mcp" target="_blank" rel="noopener" style="position:fixed;top:14px;left:14px;z-index:9999;text-decoration:none;font-family:var(--mono);font-size:12px;font-weight:700;color:var(--gold);background:rgba(0,0,0,0.6);border:1px solid var(--card-border);border-radius:var(--r-pill);padding:6px 14px;" title="faf-mcp on GitHub">v2.1.2</a>
   <div class="accent-line"></div>
 
   <div class="container">
@@ -346,7 +347,7 @@
     </div>
 
     <div class="bottom-bar">
-      <div class="bottom-left">v2.1.2 · IANA Registered · application/vnd.faf+yaml</div>
+      <div class="bottom-left">The Interop MCP for Context · IANA Registered · application/vnd.faf+yaml</div>
       <div class="bottom-platforms">
         <span class="copy-cmd" data-cmd="npx claude-faf-mcp" title="Copy the install command — paste in any terminal or your AI">Claude</span><span class="dot">&bull;</span>
         <span class="copy-cmd" data-cmd="npx grok-faf-mcp" title="Copy the install command — paste in any terminal or your AI">Grok</span><span class="dot">&bull;</span>
@@ -367,6 +368,9 @@
         setTimeout(() => { el.textContent = orig; el.style.color = ''; }, 1500);
       });
     });
+    // Single source of truth for the version: read npm live so the badge can never drift.
+    // The hardcoded text on the badge is just a fallback if the fetch fails (offline / npm down).
+    fetch('https://registry.npmjs.org/faf-mcp/latest').then(r=>r.json()).then(d=>{if(d&&d.version)document.getElementById('versionBadge').textContent='v'+d.version;}).catch(()=>{});
   </script>
 </body>
 </html>


### PR DESCRIPTION
Applies the FAF version-placement doctrine to faf-mcp's two doc surfaces: the version appears in exactly ONE display spot per surface, always TOP-LEFT, read LIVE from npm so it can't drift. Every other spot uses the product tagline.

**Edition used:** No `## [x] — The N Edition` header exists in `CHANGELOG.md`, so per doctrine no edition was invented — used the product tagline **"The Interop MCP for Context"** (from CLAUDE.md / package metadata).

### `docs/index.html` (MCPaaS landing page)
- Added a fixed top-left version badge `id="versionBadge"` linking to the GitHub repo, styled to match the page's crimson/gold theme (mirrors the sibling `claude-faf-mcp` page pattern). Fallback text `v2.1.2`.
- Added a live-fetch script before `</body>` that reads `https://registry.npmjs.org/faf-mcp/latest` and sets the badge to `v<version>` — the single source of truth, can't drift.
- Replaced the hardcoded `v2.1.2` in the bottom-bar with the tagline: `The Interop MCP for Context · IANA Registered · application/vnd.faf+yaml`.
- Result: the only hardcoded `vX.Y.Z` left on the page is the badge fallback.

### `README.md`
- Promoted the npm version badge `![npm](https://img.shields.io/npm/v/faf-mcp)` to FIRST/top-left badge (live shields = single drift-proof version reference).
- Removed the duplicate npm badge from the lower badge cluster.
- h1 `faf-mcp` carried no hardcoded version, so nothing to drop; left the `via faf-cli v5.0.1` dependency callout untouched (it's a dependency reference, not this product's version).

### Verification
- `grep -E 'v[0-9]+\.[0-9]+\.[0-9]+'` → page: only the badge fallback; README: only the `faf-cli` dependency callout.
- `registry.npmjs.org/faf-mcp/latest` → 200 JSON (version 2.1.2).
- `img.shields.io/npm/v/faf-mcp` → 200.
- HTML tags balanced (body/html/head/style/script all 1:1); badge id + fetch script present.

Note: this repo shares its remote with faf-mcp-live — only faf-mcp's own files were touched.

---
Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)

🤖 Generated with [Claude Code](https://claude.com/claude-code)