### PR TITLE
ci: auto-publish to MCP Registry on release (OIDC)

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,67 @@
+name: Publish to MCP Registry
+
+# Keeps the MCP Registry (and downstream directories like Glama) in lock-step
+# with the repo: every published GitHub Release pushes the current server.json
+# to registry.modelcontextprotocol.io. No human, no hand-cranked mcp-publisher,
+# no drift (this is why claude sat at a stale v2.6.1 while the repo was at 5.7.x).
+#
+# Auth = GitHub OIDC. NO stored secret — the registry trusts the workflow's
+# identity to authorise the io.github.Wolfe-Jam/* namespace (repo owner matches).
+
+on:
+  release:
+    types: [published]      # each release = a new server.json version → publish it
+  workflow_dispatch: {}      # manual re-publish if ever needed
+
+permissions:
+  contents: read
+  id-token: write            # REQUIRED for `mcp-publisher login github-oidc`
+
+concurrency:
+  group: mcp-registry-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mcp-publisher
+        run: |
+          set -euo pipefail
+          TAG=$(curl -fsSL https://api.github.com/repos/modelcontextprotocol/registry/releases/latest \
+                  | grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | cut -d'"' -f4)
+          echo "mcp-publisher ${TAG}"
+          # Asset name carries NO version: mcp-publisher_<os>_<arch>.tar.gz
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${TAG}/mcp-publisher_linux_amd64.tar.gz" \
+            | tar -xz mcp-publisher
+          chmod +x mcp-publisher
+
+      - name: Validate server.json
+        run: ./mcp-publisher validate
+
+      - name: Check if this version is already published (idempotent)
+        id: ver
+        run: |
+          NAME=$(jq -r .name server.json)
+          LOCAL=$(jq -r .version server.json)
+          PUBLISHED=$(curl -fsSL "https://registry.modelcontextprotocol.io/v0/servers?search=${NAME}&version=latest" \
+            | jq -r --arg n "$NAME" '[.servers[].server | select(.name==$n) | .version] | first // ""')
+          if [ "$LOCAL" = "$PUBLISHED" ]; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "✓ ${NAME} v${LOCAL} is already the registry's latest — nothing to do."
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "${NAME} v${LOCAL} not yet published (registry latest: ${PUBLISHED:-none}) — will publish."
+          fi
+
+      - name: Authenticate (GitHub OIDC — no stored secret)
+        if: steps.ver.outputs.publish == 'true'
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        if: steps.ver.outputs.publish == 'true'
+        run: |
+          ./mcp-publisher publish
+          echo "Published $(jq -r .version server.json) to the MCP Registry. Glama re-syncs on its next crawl."

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   </div>
 </div>
 
+[![npm](https://img.shields.io/npm/v/faf-mcp?color=00CCFF)](https://www.npmjs.com/package/faf-mcp)
 [![FAF Trophy 100%](https://img.shields.io/badge/FAF-%F0%9F%8F%86%20100%25-000000?labelColor=FF6B35)](https://faf.one)
 [![IANA: vnd.faf+yaml](https://img.shields.io/badge/IANA-vnd.faf%2Byaml-00D4D4)](https://www.iana.org/assignments/media-types/application/vnd.faf+yaml)
 [![DOI: Context paper](https://img.shields.io/badge/DOI-Context%20paper-FF6B35)](https://doi.org/10.5281/zenodo.18251362)
@@ -18,7 +19,6 @@
 The MCP you didn't realise you needed, or wanted but didn't know who to ask, is here. Building on 62,000+ downloads across the FAF ecosystem, we bring you faf-mcp to cure your syncing pain and fuel your chosen AI with optimized context, on-demand.
 
 [![CI](https://github.com/Wolfe-Jam/faf-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/Wolfe-Jam/faf-mcp/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/npm/v/faf-mcp?color=00CCFF)](https://www.npmjs.com/package/faf-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![project.faf](https://img.shields.io/badge/project.faf-inside-00D4D4)](https://github.com/Wolfe-Jam/faf)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -280,6 +280,7 @@
   </style>
 </head>
 <body>
+  <a id="versionBadge" href="https://github.com/Wolfe-Jam/faf-mcp" target="_blank" rel="noopener" style="position:fixed;top:14px;left:14px;z-index:9999;text-decoration:none;font-family:var(--mono);font-size:12px;font-weight:700;color:var(--gold);background:rgba(0,0,0,0.6);border:1px solid var(--card-border);border-radius:var(--r-pill);padding:6px 14px;" title="faf-mcp on GitHub">v2.1.2</a>
   <div class="accent-line"></div>
 
   <div class="container">
@@ -346,7 +347,7 @@
     </div>
 
     <div class="bottom-bar">
-      <div class="bottom-left">v2.1.2 · IANA Registered · application/vnd.faf+yaml</div>
+      <div class="bottom-left">The Interop MCP for Context · IANA Registered · application/vnd.faf+yaml</div>
       <div class="bottom-platforms">
         <span class="copy-cmd" data-cmd="npx claude-faf-mcp" title="Copy the install command — paste in any terminal or your AI">Claude</span><span class="dot">&bull;</span>
         <span class="copy-cmd" data-cmd="npx grok-faf-mcp" title="Copy the install command — paste in any terminal or your AI">Grok</span><span class="dot">&bull;</span>
@@ -367,6 +368,9 @@
         setTimeout(() => { el.textContent = orig; el.style.color = ''; }, 1500);
       });
     });
+    // Single source of truth for the version: read npm live so the badge can never drift.
+    // The hardcoded text on the badge is just a fallback if the fetch fails (offline / npm down).
+    fetch('https://registry.npmjs.org/faf-mcp/latest').then(r=>r.json()).then(d=>{if(d&&d.version)document.getElementById('versionBadge').textContent='v'+d.version;}).catch(()=>{});
   </script>
 </body>
 </html>


### PR DESCRIPTION
Fleet-standard auto-publish (proven on claude-faf-mcp #84–86): keeps the MCP Registry + downstream directories (Glama) in sync with the repo. GitHub OIDC, no stored secret; idempotent (skips if the version's already live). Fires on the next release.

— *Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)*