### PR TITLE
migrate: faf-mcp → one.faf namespace

### DIFF
--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -1,8 +1,11 @@
 name: 📡 MCP Registry Publish
 
 on:
-  release:
-    types: [created]
+  # release: trigger DISABLED for the one.faf migration — the `login github-oidc` step
+  # below authorises io.github.* ONLY, so a release-triggered publish 400s on one.faf/*.
+  # Registry publish is now the manual DNS step in /pubpro (mcp-publisher login dns).
+  # Restore CI auto-publish via the DNS-ready workflow (faf-mcp-rig reference) +
+  # the FAF_ONE_MCP_PRIVATE_KEY repo secret, switching the login step to `login dns`.
   workflow_dispatch:  # manual trigger for backfills / retries
 
 jobs:

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -9,8 +9,12 @@ name: Publish to MCP Registry
 # identity to authorise the io.github.Wolfe-Jam/* namespace (repo owner matches).
 
 on:
-  release:
-    types: [published]      # each release = a new server.json version → publish it
+  # release: trigger DISABLED for the one.faf migration — `login github-oidc` below
+  # authorises io.github.* ONLY, so a release-triggered publish 400s on one.faf/*.
+  # Registry publish is now the manual DNS step in /pubpro (mcp-publisher login dns).
+  # Restore via the DNS-ready workflow (faf-mcp-rig reference) + FAF_ONE_MCP_PRIVATE_KEY.
+  #   release:
+  #     types: [published]
   workflow_dispatch: {}      # manual re-publish if ever needed
 
 permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,4 @@
+<!-- faf:start -->
 <!-- faf: faf-mcp | TypeScript | mcp | The Interop MCP for Context. Universal .faf MCP server for Cursor, Windsurf, Cline, VS Code, and all MCP-compatible IDEs. IANA-registered application/vnd.faf+yaml. Start with "Use FAF". -->
 <!-- faf: claim=project.faf | family=FAF -->
 
@@ -29,4 +30,5 @@ The Interop MCP for Context. Universal .faf MCP server for Cursor, Windsurf, Cli
 
 ---
 
-*STATUS: BI-SYNC ACTIVE — 2026-05-26T06:37:16.305Z*
+*STATUS: BI-SYNC ACTIVE — 2026-06-16T03:34:21.638Z*
+<!-- faf:end -->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "faf-mcp",
   "version": "2.1.3",
-  "mcpName": "io.github.Wolfe-Jam/faf-mcp",
+  "mcpName": "one.faf/faf-mcp",
   "description": "Persistent Project Context for Cursor, IDEs and VS Code. IANA-registered .faf format, 25 MCP tools, 309 tests.",
   "icon": "./assets/icons/faf-icon-256.png",
   "logo": "./assets/icons/faf-icon-256.png",

--- a/project.faf
+++ b/project.faf
@@ -5,6 +5,7 @@ project:
   main_language: TypeScript
   type: mcp
   framework: MCP SDK (TS)
+  homepage: https://faf.one
 stack:
   frontend: slotignored
   css_framework: slotignored

--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.Wolfe-Jam/faf-mcp",
+  "name": "one.faf/faf-mcp",
   "title": ".FAF Context",
   "description": "Dedicated IDE Edition. Persistent project context for Cursor, Windsurf, Cline, VS Code.",
   "websiteUrl": "https://faf.one",
@@ -49,5 +49,16 @@
         "type": "stdio"
       }
     }
-  ]
+  ],
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "one.faf/context": {
+        "faf": "./project.faf",
+        "mediaType": "application/vnd.faf+yaml",
+        "iana": "https://www.iana.org/assignments/media-types/application/vnd.faf+yaml",
+        "deterministic": true,
+        "generated": "2026-06-16T03:32:22.146Z"
+      }
+    }
+  }
 }


### PR DESCRIPTION
Identity rewrite: `io.github.Wolfe-Jam/faf-mcp` → `one.faf/faf-mcp`.

- `project.faf`: + `homepage: https://faf.one` (derives the namespace)
- `package.json`: `mcpName` → `one.faf/faf-mcp` — npm package name `faf-mcp` **unchanged** (downloads preserved: 598/wk, 5,290/yr)
- `server.json`: `name` → `one.faf/faf-mcp`; `_meta` = faf-cli emitter block (registryMeta, nested under publisher-provided); no remotes to drop
- CI: disabled the `release:` OIDC triggers (OIDC authorises io.github.* only → 400s on one.faf); registry publish is the manual DNS step in /pubpro

Identity only — /pubpro ships the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)