### PR TITLE
fix(engine-adapter): cwd path-check — stop forcing ~/Projects over the open workspace

### DIFF
--- a/src/handlers/engine-adapter.ts
+++ b/src/handlers/engine-adapter.ts
@@ -108,7 +108,29 @@ export class FafEngineAdapter {
       return mcpWorkingDir;
     }
 
-    // Priority 3: FORCE ~/Projects as universal default
+    // Priority 3 (FIX 2026-06-30): the caller's ACTUAL working directory — the
+    // workspace an IDE / MCP host (Cursor, VS Code, Claude Desktop) launches the
+    // server in. This MUST win over the ~/Projects convention below. Previously
+    // ~/Projects was FORCED here, so every no-path tool call (faf_score, …)
+    // operated on ~/Projects instead of the project the user actually had open —
+    // the editor surface's whole value, silently broken (scored ~/Projects's
+    // stale .faf for everyone). Prefer a real FAF project (cwd contains
+    // project.faf — the path-check), else the cwd itself when it's a usable,
+    // non-root directory (so faf_init/score act on the open workspace even
+    // before a .faf exists).
+    const currentDir = process.cwd();
+    const usableCwd =
+      currentDir !== '/' && currentDir !== '/root' && fs.existsSync(currentDir);
+    if (usableCwd && fs.existsSync(path.join(currentDir, 'project.faf'))) {
+      return currentDir;
+    }
+    if (usableCwd) {
+      return currentDir;
+    }
+
+    // Priority 4: ~/Projects convention — a soft landing ONLY when the host gave
+    // us no usable workspace (e.g. cwd is the filesystem root). Never overrides a
+    // real cwd above.
     const homeDir = process.env.HOME ?? process.env.USERPROFILE;
     if (homeDir) {
       // Try capitalized Projects first (macOS/Windows convention)
@@ -131,12 +153,6 @@ export class FafEngineAdapter {
         // Fall back to home
         return homeDir;
       }
-    }
-
-    // Priority 4: Current directory if not root
-    const currentDir = process.cwd();
-    if (currentDir !== '/' && currentDir !== '/root' && fs.existsSync(currentDir)) {
-      return currentDir;
     }
 
     // Last resort: /tmp (should rarely happen)

--- a/tests/wjttc-cwd-resolution.test.ts
+++ b/tests/wjttc-cwd-resolution.test.ts
@@ -1,0 +1,62 @@
+/**
+ * 🏁 WJTTC — working-directory resolution (the cwd path-check)
+ *
+ * Regression for the "FORCE ~/Projects as universal default" bug: the engine
+ * adapter resolved the working directory to ~/Projects ABOVE the caller's cwd,
+ * so every no-path tool call (faf_score, …) operated on ~/Projects instead of
+ * the project the IDE/MCP host had open. In Cursor — where the host launches
+ * the server in the workspace — that meant scoring the wrong folder for everyone.
+ *
+ * The fix: the caller's actual cwd wins. Prefer a real FAF project (cwd has a
+ * project.faf — the path-check), else the cwd itself when usable + non-root;
+ * ~/Projects is a fallback ONLY when there's no usable workspace (cwd is root).
+ */
+import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { FafEngineAdapter } from '../src/handlers/engine-adapter';
+
+let tmp: string;
+let origCwd: string;
+
+beforeEach(() => {
+  origCwd = process.cwd();
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cwd-resolve-'));
+});
+afterEach(() => {
+  process.chdir(origCwd);
+  try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+describe('AERO — cwd path-check wins over the ~/Projects convention', () => {
+  test('cwd containing a project.faf is the working directory (not ~/Projects)', () => {
+    fs.writeFileSync(path.join(tmp, 'project.faf'), 'faf_version: "3.0"\nproject:\n  name: t\n');
+    process.chdir(tmp);
+    const adapter = new FafEngineAdapter();
+    // fs.realpath to dodge /var↔/private symlink noise on macOS tmp.
+    expect(fs.realpathSync(adapter.getWorkingDirectory())).toBe(fs.realpathSync(tmp));
+  });
+
+  test('a usable non-root cwd WITHOUT a .faf is still preferred over ~/Projects', () => {
+    // The open workspace before `faf_init` — faf_init/score must act here, not ~/Projects.
+    process.chdir(tmp);
+    const adapter = new FafEngineAdapter();
+    expect(fs.realpathSync(adapter.getWorkingDirectory())).toBe(fs.realpathSync(tmp));
+  });
+
+  test('explicit FAF_WORKING_DIR still overrides everything (priority 1 intact)', () => {
+    const override = fs.mkdtempSync(path.join(os.tmpdir(), 'cwd-override-'));
+    process.chdir(tmp);
+    const prev = process.env.FAF_WORKING_DIR;
+    process.env.FAF_WORKING_DIR = override;
+    try {
+      const adapter = new FafEngineAdapter();
+      expect(fs.realpathSync(adapter.getWorkingDirectory())).toBe(fs.realpathSync(override));
+    } finally {
+      if (prev === undefined) delete process.env.FAF_WORKING_DIR;
+      else process.env.FAF_WORKING_DIR = prev;
+      fs.rmSync(override, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## The bug

`findBestWorkingDirectory()` **FORCED `~/Projects` as the "universal default" above `process.cwd()`**. Every no-path tool call (`faf_score`, …) resolved to `~/Projects` instead of the project the IDE/MCP host had open.

In **Cursor** — which launches the MCP server in the workspace — `faf_score` scored `~/Projects`'s stale `.faf` (**29% / 6-of-21**) for *every* user, never their actual project. Ship-blocking for the editor surface, and exactly where we were about to pitch IDE FAF.

**faf-cli, `scoreFafYaml`, the scoring kernel were all innocent** — every version returns 94% on the same file. The divergence was pure working-directory resolution.

## The fix (a "simple path-check")

Reorder so the caller's **actual cwd wins**:

| Priority | Before | After |
|---|---|---|
| 1–2 | `FAF_WORKING_DIR` / `MCP_WORKING_DIR` | unchanged |
| 3 | **FORCE `~/Projects`** | **cwd with `project.faf`** (path-check), then **usable non-root cwd** |
| 4 | cwd if not root *(unreachable)* | `~/Projects` — fallback **only** when cwd is unusable (root) |

`faf_init`/`score` now act on the open workspace even before a `.faf` exists; `~/Projects` is preserved purely for the genuine "no workspace" case (host launched at `/`).

## Verification

- `faf_score` (no path) in a real project → **94%** (was 29%)
- explicit `path` → 94% (unchanged)
- `cwd=/` → 29% via `~/Projects` (fallback preserved)
- New `tests/wjttc-cwd-resolution.test.ts` (3 tests) + path-confinement / conformance / parity suites → **50 pass / 0 fail**, typecheck clean

## Blast radius (sweep)

The **identical** `findBestWorkingDirectory()` ships in **`grok-faf-mcp`** and **`claude-faf-mcp`** (shared lineage). Grok FAF dodges it for `faf_score` (its handler uses `process.cwd()` directly) but the landmine remains for any `callEngine` path. **Same fix to follow in each, separate PRs.**

— *Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)*