### PR TITLE
chore(release): faf-mcp 2.3.1 — cwd path-check fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- faf: faf-mcp | TypeScript | mcp-server | FAF MCP IDE Edition — persistent project context for Cursor, Windsurf, Cline, VS Code -->
-<!-- faf: doc=changelog | latest=v2.3.0 | canonical=project.faf | family=FAF -->
+<!-- faf: doc=changelog | latest=v2.3.1 | canonical=project.faf | family=FAF -->
 
 # Changelog
 
@@ -9,6 +9,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.3.1] - 2026-06-30
+
+### Fixed
+- **Working-directory resolution (cwd path-check).** `findBestWorkingDirectory()`
+  forced `~/Projects` as a "universal default" *above* `process.cwd()`, so every
+  no-path tool call (`faf_score`, …) operated on `~/Projects`'s `.faf` instead of
+  the project the IDE/host had open. In Cursor — which launches the server in the
+  workspace — that meant scoring the wrong folder (a stale `~/Projects`
+  score, never the real project). The caller's actual cwd now wins: prefer a real
+  FAF project (cwd contains `project.faf` — the path-check), else the cwd itself
+  when it's a usable, non-root directory. `~/Projects` remains a fallback **only**
+  when there's no usable workspace (cwd is the filesystem root), preserving the
+  no-context launch case. Regression test: `tests/wjttc-cwd-resolution.test.ts`.
+  faf-cli, `scoreFafYaml` and the scoring kernel were never at fault — this was
+  purely working-directory resolution.
 
 ## [2.3.0] - 2026-06-23 — The Curated Edition
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faf-mcp",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "mcpName": "one.faf/faf-mcp",
   "description": "Persistent Project Context for Cursor, IDEs and VS Code. IANA-registered .faf format, 31 MCP tools, 309 tests.",
   "icon": "./assets/icons/faf-icon-256.png",

--- a/server.json
+++ b/server.json
@@ -38,12 +38,12 @@
     "url": "https://github.com/Wolfe-Jam/faf-mcp",
     "source": "github"
   },
-  "version": "2.3.0",
+  "version": "2.3.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "faf-mcp",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
**Release prep for `faf-mcp 2.3.1`** — version + CHANGELOG for the cwd path-check fix already merged in [#67](https://github.com/Wolfe-Jam/faf-mcp/pull/67). Publish is via **`/pubpro`** after this merges (npm + MCP registry) — this PR is prep only.

### What ships
The **cwd path-check fix**: no-path `faf_score` (and every engine-adapter tool) now scores the project the IDE/host has open, not `~/Projects`. Fixes the Cursor-facing bug for real users the moment it's published, and makes the cross-surface receipt (IDE FAF + Grok FAF → matching 94) real.

### Changes (doc/version only — code already on `main`)
| File | Change |
|------|--------|
| `package.json` | `2.3.0` → `2.3.1` |
| `CHANGELOG.md` | meta-stamp `latest=v2.3.1` + `## [2.3.1]` entry |
| `server.json` | both `version` fields → `2.3.1` |

Patch → **inherits "The Curated Edition"** (no new edition name, per the doc gate). All version stamps consistent (`package.json` · CHANGELOG meta + entry · `server.json` ×2) — Doc Gate 101 clean.

### After merge
Run **`/pubpro`** for faf-mcp → FAF gate + npm publish + MCP registry + round-trip. Brand stays **`.FAF Context`** (already live; no branding work).

— *Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)*