### PR TITLE
docs(2.3.1): structural tool-count framing + sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,11 +12,11 @@ The Interop MCP for Context — the Cursor / IDE Edition. Persistent context for
 
 - **Language:** TypeScript
 - **Backend:** MCP SDK (TS)
-- **Api Type:** MCP (stdio + Streamable HTTP)
+- **API:** MCP (stdio + Streamable HTTP)
 - **Runtime:** Node.js >=18
 - **Hosting:** npm + Cloudflare edge
 - **Build:** TypeScript (tsc)
-- **Cicd:** GitHub Actions
+- **CI/CD:** GitHub Actions
 - **Package Manager:** npm
 
 ## Context
@@ -30,5 +30,5 @@ The Interop MCP for Context — the Cursor / IDE Edition. Persistent context for
 
 ---
 
-*STATUS: BI-SYNC ACTIVE — 2026-06-23T15:53:22.301Z*
+*STATUS: BI-SYNC ACTIVE — 2026-07-01T01:00:16.899Z*
 <!-- faf:end -->

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "faf-mcp",
   "version": "2.3.1",
   "mcpName": "one.faf/faf-mcp",
-  "description": "Persistent Project Context for Cursor, IDEs and VS Code. IANA-registered .faf format, 31 MCP tools, 309 tests.",
+  "description": "Persistent Project Context for Cursor, IDEs and VS Code. IANA-registered .faf format. Curated core tools by default, full set via FAF_TOOLS=all.",
   "icon": "./assets/icons/faf-icon-256.png",
   "logo": "./assets/icons/faf-icon-256.png",
   "displayName": ".faf 🐘",


### PR DESCRIPTION
Final doc polish for the **2.3.1** ship (cwd fix in [#67](https://github.com/Wolfe-Jam/faf-mcp/pull/67), version bump in [#68](https://github.com/Wolfe-Jam/faf-mcp/pull/68)). Publish via **`/pubpro`** after merge.

- **`package.json`** — the npm description now frames the tool surface **structurally**: *"Curated core tools by default, full set via FAF_TOOLS=all."* Replaces the pinned (and wrong: `31`) integer. FAF doesn't publish exact tool counts — they drift and nobody counts them.
- **`CLAUDE.md`** — `faf sync` output (label formatting + bi-sync timestamp). project.faf is 🏆 Trophy 100%.

No code change — the fix already shipped in #67.

— *Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)*