### PR TITLE
docs: lead README hero with the .FAF Context brand

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 <div style="display: flex; align-items: center; gap: 12px;">
   <img src="https://www.faf.one/orange-smiley.svg" alt="FAF" width="40" />
   <div>
-    <h1 style="margin: 0; color: #FF8C00;">faf-mcp</h1>
-    <p style="margin: 4px 0 0 0;"><strong>Persistent Project Context for Cursor, IDEs and VS Code. Define once. Sync everywhere.</strong></p>
+    <h1 style="margin: 0; color: #FF8C00;">.FAF Context</h1>
+    <p style="margin: 4px 0 0 0;"><strong>Persistent Project Context for Cursor, IDEs and VS Code. Define once. Sync everywhere.</strong> <sub>npm: <code>faf-mcp</code></sub></p>
   </div>
 </div>
 


### PR DESCRIPTION
Final branding polish for the **2.3.1** ship. The README hero led with the *package name* `faf-mcp`; the *product name* is **`.FAF Context`** — already the live display name on GitHub MCP + PulseMCP (`server.json` title).

**Hero now:**
> # 🙂 .FAF Context
> **Persistent Project Context for Cursor, IDEs and VS Code. Define once. Sync everywhere.** <sub>npm: `faf-mcp`</sub>

Brand up top, install string below — the `Next.js`→`next` pattern. Package name unchanged (`faf-mcp`), so zero DL/install impact. The GitHub release will also title **`.FAF Context v2.3.1`**.

— *Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)*