### PR TITLE
docs: download figure → 100,000+ linked to the milestone receipt

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 **Home:** [wolfe-jam.github.io/faf-mcp](https://wolfe-jam.github.io/faf-mcp/) · **Hosted MCP endpoint:** `https://ide.faf.one/mcp/v1` (Streamable HTTP)
 
-The MCP you didn't realise you needed, or wanted but didn't know who to ask, is here. Building on 62,000+ downloads across the FAF ecosystem, we bring you faf-mcp to cure your syncing pain and fuel your chosen AI with optimized context, on-demand.
+The MCP you didn't realise you needed, or wanted but didn't know who to ask, is here. Building on [100,000+](https://faf.one/blog/hundred-thousand) downloads across the FAF ecosystem, we bring you faf-mcp to cure your syncing pain and fuel your chosen AI with optimized context, on-demand.
 
 [![CI](https://github.com/Wolfe-Jam/faf-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/Wolfe-Jam/faf-mcp/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
Final polish for the **2.3.1** ship. The README claimed **"62,000+ downloads"** while `docs/THE-MISSING-FORMAT*.md` say **"13,000+"** — same repo, different numbers. Standardized on the **SAFE canonical claim**:

> Building on **[100,000+](https://faf.one/blog/hundred-thousand)** downloads across the FAF ecosystem…

- `100,000+` is a conservative, defensible figure (wolfejam: "SAFE, use it")
- The number **links to its receipt** — the milestone article (verified HTTP 200 via browser-UA; faf.one Cloudflare 403s bot fetches)
- The live npm **badge** already tracks exactness, so prose never has to chase it

⚠️ Separately (not in this PR): `docs/THE-MISSING-FORMAT*.md` still say `13,000+` **and** read like strategy/social docs that per house rules don't belong in a public repo — flagged for a post-ship cleanup.

— *Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)*