### PR TITLE
docs: add "Add to Cursor" one-click install button

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ You maintain `.cursorrules`. Your teammate uses `AGENTS.md`. Someone on the team
 
 ### Quick Start
 
+**Cursor — one click:** [![Add .FAF Context to Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](cursor://anysphere.cursor-deeplink/mcp/install?name=faf-mcp&config=eyJjb21tYW5kIjoiYnVueCIsImFyZ3MiOlsiZmFmLW1jcCJdfQ==)
+
+**Everywhere else:**
+
 ```bash
 bunx faf-mcp
 ```


### PR DESCRIPTION
Adds a one-click **Add to Cursor** button to the README Quick Start — the self-service Cursor distribution lever (no directory approval needed).

**Button:**
> [![Add .FAF Context to Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/docs/context/mcp/install-links)

**Deeplink:** `cursor://anysphere.cursor-deeplink/mcp/install?name=faf-mcp&config=<base64>` where config = `{"command":"bunx","args":["faf-mcp"]}` — per [Cursor's MCP Install Links docs](https://cursor.com/docs/context/mcp/install-links). The dark/light SVGs are Cursor's official button assets (both resolve 200).

⚠️ **Please click-test it in Cursor before merging** — the `cursor://` deeplink format has drifted before ([github-mcp #860](https://github.com/github/github-mcp-server/issues/860)) and I can't test the protocol handler from here. If it doesn't fire, I'll adjust the config/name encoding.

Part of the Cursor distribution TODO (GitHub Registry + VS Code already confirmed live via the MCP Registry).

— *Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)*