### PR TITLE
docs: FAF authors context — generate→author copy sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ faf-mcp now **enhances** your context files instead of replacing them — a stru
 
 ### Changed
 
-- **Non-destructive interop.** `faf_cursor`, `faf_agents`, `faf_gemini`, and `faf_sync` now inject a structured `.faf` block at the top of .cursorrules, AGENTS.md, GEMINI.md, and CLAUDE.md and preserve everything you've written below. Re-runs update the block in place (idempotent); existing faf-generated files upgrade cleanly in one pass.
+- **Non-destructive interop.** `faf_cursor`, `faf_agents`, `faf_gemini`, and `faf_sync` now inject a structured `.faf` block at the top of .cursorrules, AGENTS.md, GEMINI.md, and CLAUDE.md and preserve everything you've written below. Re-runs update the block in place (idempotent); existing faf-authored files upgrade cleanly in one pass.
 - **Composes faf-cli's single-source engines.** Turbo-Cat (~200-format detection) and the 6Ws interview now come from faf-cli — faf-mcp's own forks are deleted. One source of truth, no drift between the CLI and the server.
 - **Migrated to the `one.faf` namespace.** MCP Registry identity `io.github.Wolfe-Jam/faf-mcp` → `one.faf/faf-mcp` (DNS-verified), carrying the single-source `one.faf/context` `_meta` block emitted by faf-cli. The npm package `faf-mcp`, its tools, and its downloads are **unchanged** — only the registry identity moves.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You maintain `.cursorrules`. Your teammate uses `AGENTS.md`. Someone on the team
 
 **faf-mcp is the dedicated MCP server for Cursor, Windsurf, Cline, VS Code, and every non-Claude platform.** One `.faf` file in your repo, synced to every format your team needs.
 
-**Context for Cursor & IDE agents:** faf-cli (v7.1) generates the files this server syncs — `bunx faf export --agents`, zero-install and git-native. See [FAF-CLI for Cursor & IDE agents 👀](https://github.com/Wolfe-Jam/faf-cli/blob/main/docs/faf-cli-for-agents.md).
+**Context for Cursor & IDE agents:** faf-cli (v7.1) authors the files this server syncs — `bunx faf export --agents`, zero-install and git-native. See [FAF-CLI for Cursor & IDE agents 👀](https://github.com/Wolfe-Jam/faf-cli/blob/main/docs/faf-cli-for-agents.md).
 
 ```
                       project.faf
@@ -108,7 +108,7 @@ npx faf-mcp
 | `faf_cursor` | Cursor IDE | Import/export/sync .cursorrules |
 | `faf_gemini` | Google Gemini | Import/export/sync GEMINI.md |
 | `faf_conductor` | Conductor | Import/export directory structure |
-| `faf_git` | GitHub | Generate .faf from any repo URL |
+| `faf_git` | GitHub | Author .faf from any repo URL |
 
 ```bash
 # Sync to all formats at once
@@ -214,7 +214,7 @@ Works on all platforms — stops web search, forces tool usage.
 | `faf_cursor` | Import/export/sync .cursorrules |
 | `faf_gemini` | Import/export/sync GEMINI.md |
 | `faf_conductor` | Import/export directory structure |
-| `faf_git` | Generate .faf from GitHub repo URL |
+| `faf_git` | Author .faf from GitHub repo URL |
 | **Cloud Tools** | |
 | `faf_cloud_publish` | Upload to mcpaas.live |
 | `faf_cloud_fetch` | Pull from cloud |


### PR DESCRIPTION
## What

Copy sweep of user-facing prose: replaced the "generate" word-family with the "author" family **only where it describes FAF / the faf-mcp tool authoring context output** (`.faf`, AGENTS.md, .cursorrules, GEMINI.md, CLAUDE.md). FAF *authors* context — reads repo → discerns → authors from intel; it never "generates" it.

## Changed (4)

- **README.md:39** — "faf-cli (v7.1) **generates** the files this server syncs" → "**authors**"
- **README.md:111** — `faf_git` action: "**Generate** .faf from any repo URL" → "**Author**"
- **README.md:217** — `faf_git` action: "**Generate** .faf from GitHub repo URL" → "**Author**"
- **CHANGELOG.md:61** — "existing **faf-generated** files upgrade cleanly" → "**faf-authored**"

## Deliberately left untouched

- **README.md:117** — `# Generate .faf from any GitHub repo` — comment inside a fenced ```bash code block
- **README.md:135 / 223** — "Generate share links" — share-link generation, not context output
- **CHANGELOG.md:120** — `generateProjectHtml` — code identifier / function name
- **CHANGELOG.md:159** — `faf-git-generator` — bundled-parser module name
- **CHANGELOG.md:204** — "Generate shareable links for instant access" — share links, not context

Conservative sweep — under-change over over-change. No source, tests, lockfiles, or literal commands touched. `package.json` description had no hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)